### PR TITLE
Add links to RSS feeds

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -9,6 +9,9 @@
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}">
     <title>{{ if eq .Title .Site.Title }}{{ .Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
     <link rel="canonical" href="{{ .Permalink }}">
+    {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
     {{ .Hugo.Generator }}
     <meta name="theme-color" content="#{{ .Site.Params.brand }}">
     <script>


### PR DESCRIPTION
Fixes #32 

I'm running this on my own status pages, so it is well tested. It is the recommended way to do this according to Hugo as well: https://gohugo.io/templates/rss/