### PR TITLE
Fix issue of missing resolved field in Netlify

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -28,7 +28,7 @@ collections:
       - {label: "Mark as incident", name: "section", widget: "hidden", default: "issue"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Start date & time (your time)", name: "date", widget: "datetime"}
-      - {label: "Mark as resolved", name: "resolved", widget: "boolean", required: false}
+      - {label: "Mark as resolved", name: "resolved", widget: "boolean", required: false, default: false}
       - {label: "End date & time (your time)", name: "resolvedWhen", widget: "datetime", required: false}
       - label: "Affected systems (use exact name, separated by commas)"
         name: "affected"


### PR DESCRIPTION
According to the documentation [here](https://www.netlifycms.org/docs/widgets/) for Boolean (you may need to select the type) a Boolean can have a default applied to it. The default when creating a new issue and nothing being changed in the `Resolved` switch should be to default to `false`.

As issue #65 says, if you do not have a `resolved` field in the incident metadata the components / systems will not be given the severity you have specified in the incident.

Closes #65 