### PR TITLE
v4.0.1

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -183,7 +183,7 @@ params:
   # most of the interface to ensure
   # a good user experience.
   #
-  # Default: false
+  # Default: `false`
   # BOOLEAN; `true`, `false`
   disableDarkMode: false
 
@@ -261,9 +261,23 @@ params:
   # and use the status indication
   # colors that were just defined?
   #
-  # Default: true
+  # Default: `true`
   # BOOLEAN; `true`, `false`
   alwaysKeepBrandColor: true
+  
+  # Introduced in v4.0.1 for consistent
+  # site title text color.
+  #
+  # If you do not use the logo, what color
+  # should the site text color be?
+  #
+  # Removing this option will not force
+  # any site text color. This is likely
+  # unwanted behavior.
+  #
+  # Default: `white`
+  # STRING; `white`, `black`, or nothing
+  headerTextColor: white
 
   # Google Analytics tracking code
   #

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -5,7 +5,7 @@
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 {
   "is": "index",
-  "cStateVersion": "4.0.0",
+  "cStateVersion": "4.0.1",
   "apiVersion": "1.0.0",
   "title": "{{ .Site.Title }}",
   "languageCodeHTML": "{{ .Site.LanguageCode }}",

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -3,7 +3,7 @@
    * Dev toolset
    */
 
-  console.log('cState v4.0.0 - https://github.com/cstate/cstate');
+  console.log('cState v4.0.1 - https://github.com/cstate/cstate');
   document.getElementsByTagName('html')[0].className = 'js';
 
   /**

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -12,7 +12,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
-    <meta name="generator" content="cState v4.0.0 - https://github.com/cstate/cstate">
+    <meta name="generator" content="cState v4.0.1 - https://github.com/cstate/cstate">
     <meta name="theme-color" content="{{ .Site.Params.brand }}">
     <script>
     var themeBrandColor = '{{ .Site.Params.brand }}';

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -165,7 +165,13 @@
       font-size: 14px;
       font-variant: small-caps;
     }
-
+      
+    {{ if eq .Params.headerTextColor "black" }}
+      .header a h1 { color: #000; }
+    {{ else if eq .Params.headerTextColor "white" }}
+      .header a h1 { color: #fff; }
+    {{ end }}
+      
     .header__logo img {
       height: auto;
       width: 320px;


### PR DESCRIPTION
Bug fix release. Thank you to SamW on Discord for getting in touch.

First release of 2020 (on January 2nd), 433 stars at time of release (13 up since v4.0.0).

## Changelog

Introduced consistent site title text color behavior.

> If you do not use the logo, what color should the site text color be?

Add `headerTextColor: white` or `headerTextColor: black` under `.Params`.