### PR TITLE
use name as default when overriding system display name

### DIFF
--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -60,7 +60,7 @@
 
         <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
           <a href="/affected/{{ .name | urlize }}" class="no-underline">
-            {{ default .displayName .name }}
+            {{ default .name .displayName }}
           </a>
 
           {{ with .description }}


### PR DESCRIPTION
The change in pull request #99 has inverted arguments, therefore the overridden `displayName` is never taken into account. This change puts them in the correct order according to the [documentation](https://gohugo.io/functions/default/) and actually closes #98 .
