### PR TITLE
fix issue with disableComplexCalculations param being incorrectly ref…

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,7 @@
 
         
         <!-- Average downtime -->
-        {{ if not .Params.disableComplexCalculations }}
+        {{ if not .Site.Params.disableComplexCalculations }}
         <p class="bold">
           <em>
             {{ $resolved := first 5 (where .Pages "Params.resolved" "=" true) }}


### PR DESCRIPTION
`.Params.disableComplexCalculations` is not defined, we need to prepend `.Site`, like how we reference other params in the same file.

Tested locally with `disableComplexCalculations` set to false and all works as expected.