### PR TITLE
Add config option to disable incident history

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -172,7 +172,7 @@ params:
   # STRING; `monthly`, `yearly`, `none`
   incidentHistoryFormat: "yearly"
 
-  # Should incident history be enabled?
+  # Should incident history be hidden?
   #
   # By disabling the incident history, you also disable
   # the RSS feed. To ensure no incidents are shown, you
@@ -180,9 +180,9 @@ params:
   # overrides any other options that tailor your incident
   # history’s look.
   #
-  # Default: `true`
+  # Default: `false`
   # BOOLEAN; `true`, `false`
-  enableIncidentHistory: true
+  disableIncidentHistory: false
 
   # Disable dark mode
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -172,6 +172,12 @@ params:
   # STRING; `monthly`, `yearly`, `none`
   incidentHistoryFormat: "yearly"
 
+  # Should incident history be enabled?
+  #
+  # Default: `true`
+  # BOOLEAN; `true`, `false`
+  enableHistory: true
+
   # Disable dark mode
   #
   # If your OS and browser support the

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -174,9 +174,15 @@ params:
 
   # Should incident history be enabled?
   #
+  # By disabling the incident history, you also disable
+  # the RSS feed. To ensure no incidents are shown, you
+  # should delete them after they are resolved. This option
+  # overrides any other options that tailor your incident
+  # history’s look.
+  #
   # Default: `true`
   # BOOLEAN; `true`, `false`
-  enableHistory: true
+  enableIncidentHistory: true
 
   # Disable dark mode
   #

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,16 +37,18 @@
   {{ partial "index/tabs" . }}
 
   <!-- All incidents + pagination -->
-  <div class="contain contain--more" id="incidents">
-    {{ if eq .Site.Params.incidentHistoryFormat "yearly" }}
-      {{ partial "index/incidents-yearly" . }}
-    {{ else if eq .Site.Params.incidentHistoryFormat "monthly" }}
-      {{ partial "index/incidents-monthly" . }}
-    {{ else }}
-      {{ partial "index/incidents" . }}
-    {{ end }}
-    <div class="padding"></div>
-  </div>
+  {{ if .Site.Params.enableHistory }}
+    <div class="contain contain--more" id="incidents">
+      {{ if eq .Site.Params.incidentHistoryFormat "yearly" }}
+        {{ partial "index/incidents-yearly" . }}
+      {{ else if eq .Site.Params.incidentHistoryFormat "monthly" }}
+        {{ partial "index/incidents-monthly" . }}
+      {{ else }}
+        {{ partial "index/incidents" . }}
+      {{ end }}
+      <div class="padding"></div>
+    </div>
+  {{ end }}
 
   {{ partial "js" . }}
   {{ partial "footer" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
   {{ partial "index/tabs" . }}
 
   <!-- All incidents + pagination -->
-  {{ if .Site.Params.enableHistory }}
+  {{ if not .Site.Params.disableIncidentHistory }}
     <div class="contain contain--more" id="incidents">
       {{ if eq .Site.Params.incidentHistoryFormat "yearly" }}
         {{ partial "index/incidents-yearly" . }}

--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -1,30 +1,32 @@
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <!--
-    <link rel="alternate" type="text/html" href="{{ .Site.BaseURL }}"/> -->
-    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link>{{ .Permalink }}</link>
-    <description>{{ T "incidentHistory" }}</description>
-    <generator>github.com/cstate</generator>
-    {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
-    {{ if not .Date.IsZero }}
-    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-    {{ end }}
-    {{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}
-    {{ with .OutputFormats.Get "RSS" }}
-      {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
-    {{ end }}
-    {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
-    {{ range $incidents }}
-      <item>
-        <title>{{ if .Params.resolved }}[{{ T "resolved" }}] {{ end }}{{ .Title }}</title>
-        <link>{{ .Permalink }}</link>
-        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        <guid>{{ .Permalink }}</guid>
-        <category>{{ .Params.resolvedWhen }}</category>
-        <description>{{ .Content | html }}</description>
-      </item>
-    {{ end }}
-  </channel>
-</rss>
+{{ if .Site.Params.enableHistory }}
+  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+      <!--
+      <link rel="alternate" type="text/html" href="{{ .Site.BaseURL }}"/> -->
+      <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+      <link>{{ .Permalink }}</link>
+      <description>{{ T "incidentHistory" }}</description>
+      <generator>github.com/cstate</generator>
+      {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
+      {{ if not .Date.IsZero }}
+      <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+      {{ end }}
+      {{ with .Site.Copyright }}
+      <copyright>{{.}}</copyright>{{end}}
+      {{ with .OutputFormats.Get "RSS" }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+      {{ end }}
+      {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
+      {{ range $incidents }}
+        <item>
+          <title>{{ if .Params.resolved }}[{{ T "resolved" }}] {{ end }}{{ .Title }}</title>
+          <link>{{ .Permalink }}</link>
+          <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+          <guid>{{ .Permalink }}</guid>
+          <category>{{ .Params.resolvedWhen }}</category>
+          <description>{{ .Content | html }}</description>
+        </item>
+      {{ end }}
+    </channel>
+  </rss>
+{{ end }}

--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -1,4 +1,4 @@
-{{ if .Site.Params.enableHistory }}
+{{ if not .Site.Params.disableIncidentHistory }}
   <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
       <!--

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,22 +13,24 @@
     <!-- Please keep this one around to help cState grow <3 -->
     <small class="footer__copyright faded">{{ T "poweredBy" }} <a href="https://github.com/cstate/cstate"><b>cState</b></a></small>
 
-    <hr>
-
-    <p class="hinted">
-      <small>
-        ⚡
-        {{ T "rss" }} —
-        {{ with $.Site.Home.OutputFormats.Get "rss" }}
-          <a href="{{ .Permalink }}" class="no-underline">{{ T "toAllUpdates" }}</a>
-        {{ end }}
-        {{ if not .IsHome }}
-        {{ with .OutputFormats.Get "rss" }}
-          {{ T "or" }} <a href="{{ .Permalink }}" class="no-underline">{{ T "onlyThisFeed" }} ({{ $.Title }})</a>
-        {{ end }}
-        {{ end }}
-      </small>
-    </p>
+    {{ if .Site.Params.enableHistory }}
+      <hr>
+      
+      <p class="hinted">
+        <small>
+          ⚡
+          {{ T "rss" }} —
+          {{ with $.Site.Home.OutputFormats.Get "rss" }}
+            <a href="{{ .Permalink }}" class="no-underline">{{ T "toAllUpdates" }}</a>
+          {{ end }}
+          {{ if not .IsHome }}
+          {{ with .OutputFormats.Get "rss" }}
+            {{ T "or" }} <a href="{{ .Permalink }}" class="no-underline">{{ T "onlyThisFeed" }} ({{ $.Title }})</a>
+          {{ end }}
+          {{ end }}
+        </small>
+      </p>
+    {{ end }}
   </div>
 </div>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
     <!-- Please keep this one around to help cState grow <3 -->
     <small class="footer__copyright faded">{{ T "poweredBy" }} <a href="https://github.com/cstate/cstate"><b>cState</b></a></small>
 
-    {{ if .Site.Params.enableHistory }}
+    {{ if not .Site.Params.disableIncidentHistory }}
       <hr>
       
       <p class="hinted">

--- a/layouts/partials/index/tabs.html
+++ b/layouts/partials/index/tabs.html
@@ -13,7 +13,7 @@
     </div>
   </div>
 {{ else }}
-  {{ if .Site.Params.enableHistory }}
+  {{ if not .Site.Params.disableIncidentHistory }}
     <div class="contain contain--more">
       <h2 class="center">{{ T "incidentHistory" }}</h2>
       <hr class="clean">

--- a/layouts/partials/index/tabs.html
+++ b/layouts/partials/index/tabs.html
@@ -13,8 +13,10 @@
     </div>
   </div>
 {{ else }}
-  <div class="contain contain--more">
-    <h2 class="center">{{ T "incidentHistory" }}</h2>
-    <hr class="clean">
-  </div>
+  {{ if .Site.Params.enableHistory }}
+    <div class="contain contain--more">
+      <h2 class="center">{{ T "incidentHistory" }}</h2>
+      <hr class="clean">
+    </div>
+  {{ end }}
 {{ end }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -193,6 +193,12 @@ collections:
                 min: 1
                 max: 100
                 default: 10
+              # Incidents history
+              - label: 'Should the incident history be enabled?'
+                name: 'incidentHistoryFormat'
+                hint: 'This also disables the RSS feed.'
+                widget: 'boolean'
+                default: true
               # Incidents view format
               - label: 'Should the incident history be sorted by year or month?'
                 name: 'incidentHistoryFormat'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -194,11 +194,11 @@ collections:
                 max: 100
                 default: 10
               # Incidents history
-              - label: 'Should the incident history be shown?'
-                name: 'enableIncidentHistory'
+              - label: 'Should the incident history be hidden?'
+                name: 'disableIncidentHistory'
                 hint: 'By disabling the incident history, you also disable the RSS feed. To ensure no incidents are shown, you should delete them after they are resolved. This option overrides any other options that tailor your incident history’s look.'
                 widget: 'boolean'
-                default: true
+                default: false
               # Incidents view format
               - label: 'Should the incident history be sorted by year or month?'
                 name: 'incidentHistoryFormat'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -196,7 +196,7 @@ collections:
               # Incidents history
               - label: 'Should the incident history be shown?'
                 name: 'enableIncidentHistory'
-                hint: 'By disabling the incident history, you also disabl the RSS feed. To ensure no incidents are shown, you should delete them after they are resolved. This ootion overrides any other options that tailor your incident history’s look.'
+                hint: 'By disabling the incident history, you also disable the RSS feed. To ensure no incidents are shown, you should delete them after they are resolved. This option overrides any other options that tailor your incident history’s look.'
                 widget: 'boolean'
                 default: true
               # Incidents view format

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -194,9 +194,9 @@ collections:
                 max: 100
                 default: 10
               # Incidents history
-              - label: 'Should the incident history be enabled?'
-                name: 'incidentHistoryFormat'
-                hint: 'This also disables the RSS feed.'
+              - label: 'Should the incident history be shown?'
+                name: 'enableIncidentHistory'
+                hint: 'By disabling the incident history, you also disabl the RSS feed. To ensure no incidents are shown, you should delete them after they are resolved. This ootion overrides any other options that tailor your incident history’s look.'
                 widget: 'boolean'
                 default: true
               # Incidents view format


### PR DESCRIPTION

The new option enableIncidentHistory allows to enable or disable the incident history. This includes:

- No RSS feed
- No incident history in the home page
- (If easily achievable) No rendering of single incident pages, which are resolved. Note: This is not implemented in this PR, because I am not sure, if this is possible with hugo.

Explain the **details** for making this change. What existing problem does the pull request solve?

I would like to disable the incident history, as I do not need and and only want to show the current status of my systems.

**Test plan**

Just set enableIncidentHistory to false in the exampleSite and the incident history should be gone.
