### PR TITLE
Fix parameter name for headerTextColor

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -166,9 +166,9 @@
       font-variant: small-caps;
     }
       
-    {{ if eq .Params.headerTextColor "black" }}
+    {{ if eq .Site.Params.headerTextColor "black" }}
       .header a h1 { color: #000; }
-    {{ else if eq .Params.headerTextColor "white" }}
+    {{ else if eq .Site.Params.headerTextColor "white" }}
       .header a h1 { color: #fff; }
     {{ end }}
       


### PR DESCRIPTION
closes #113

Just a small mistake in the partial I believe, cf code.