### PR TITLE
Add Dockerfile to cstate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM nginx:alpine
+
+# /cstate will be our volume & building directory
+WORKDIR /cstate
+
+# Install hugo & git
+RUN apk add hugo git
+
+# -- First Run --
+
+# Download the example site
+RUN git clone https://github.com/cstate/example /cstate
+
+# Copy files from this repo into themes/cstate
+RUN mkdir -p /cstate/themes/cstate
+COPY . /cstate/themes/cstate
+
+# Prepare the entrypoint files
+COPY ./docker/entrypoint.sh /docker-entrypoint.d/10-build-hugo.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+WORK_DIR="/app"
+SRC_DIR="/cstate"
+
+# Check if the working dir is empty, if it is we'll need to copy
+# the files in from src directory (usually /cstate)
+if ! [ "$(ls -A $WORK_DIR)" ]; then
+    # First run, copy cstate's files in.
+    echo "First time run! Hello, World :)"
+    cp -R $SRC_DIR/* $WORK_DIR
+fi
+
+# Continue with building
+
+# CD into working dir
+cd /app
+
+# Build the hugo site
+hugo
+
+# Copy built files into NGINX directory
+cp -r /app/public/* /usr/share/nginx/html


### PR DESCRIPTION
This patch adds a Dockerfile to cstate, it's technically related to #50 - which was closed because I was too lazy to get this done. But here it is.

Adding a Dockerfile allows cstate to operate without a serverless system, such as Netlify, but also makes development a little easier as you don't need to install the required dependencies onto your machine, such as Hugo. This can make development on non-UNIX based systems a little easier and removes the requirement of installing Hugo to develop cstate.

This PR adds two new files: Dockerfile & docker/entrypoint.sh

The Dockerfile configures the Docker image, pulls cstate and configures it for first run.

The entrypoint script file exists to build cstate on every startup. This is required as all files are compiled into the public directory.
Once building is finished the public files are moved into NGINX's working directory and the server starts.

The Dockerfile will clone the example repo into the working directory & then install the files from this repo on top of it, this method could be improved in the future, but this solution allows the Dockerfile to work on the development environment, rather than using the submodules within the example repo.

GitHub actions could be used to build this Dockerfile into a GitHub package, or the Dockerfile could be published to Docker Hub, both of these will lower the barrier to entry on using cstate without a serverless system, the building step of the following instructions could be skipped.

I decided not to update the README in this PR, but here's the usage instructions:

## Docker Installation Guide

Clone the repo:
`git clone https://github.com/cstate/cstate`

Build the Docker image:
`cd cstate/`
`docker build -t cstate .`

Run the container (mount):
`docker run -p 8080:80 --mount type=bind,source=/var/cstate,target=/app --name=cstate cstate`

The above command will create a directory in /var called 'cstate' this is where all files will exist for modifying the issues & templates of cstate, the NGINX server will listen at port 8080.


Run the container (volume)
`docker run --rm -p 8080:80 -v cstate:/app --name=cstate cstate`

This command will create a new docker volume. This isn't recommended as modifying the files within a volume can be tricky.
The volume will be named 'cstate' and the NGINX server will listen at port 8080.

### Reloaded modified files

The easiest way to reload cstate after modifying it's files is to run `docker restart cstate` as the container will also recompile the files on startup.

If restarting the container is not an option, you can use `docker exec -it cstate /bin/ash` to launch a shell into the container, and then use the following commands;

```
cd /app
hugo
cp -r /app/public/* /usr/share/nginx/html
```

This will rebuild cstate and copy the files back into the NGINX directory.
-- End of installation guide --

p.s. Sorry for taking so long to do this 🙃
p.p.s The contribution guidelines recommend merging into the 'dev' branch - which doesn't exist.

- Nev.