### PR TITLE
cState v4.4 Development Build

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -214,7 +214,7 @@ params:
   #
   # Recommended: png, bmp, jpg, or gif
   # for best browser support!
-  logo: /logo.png
+  logo: logo.png
 
   # This is the description that is shown
   # on the footer and meta tags.

--- a/exampleSite/content/issues/2019-10-08-testing-new-pipeline.md
+++ b/exampleSite/content/issues/2019-10-08-testing-new-pipeline.md
@@ -1,8 +1,8 @@
 ---
 title: New Pipeline Rollout
-date: 2019-10-05 16:24:00
+date: 2019-10-05 16:24:00 
 resolved: false
-resolvedWhen: 2019-10-05 16:58:00
+resolvedWhen: 2019-10-05 16:58:00 
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
@@ -11,3 +11,4 @@ section: issue
 ---
 
 There may be disruptions in the rollout.
+ 

--- a/exampleSite/content/issues/2020-06-13-maintenance-window.md
+++ b/exampleSite/content/issues/2020-06-13-maintenance-window.md
@@ -1,8 +1,8 @@
 ---
 title: Maintenance Window
-date: 2018-06-13 15:54:00
+date: 2020-06-13 15:54:00
 resolved: true
-resolvedWhen: 2018-06-13 16:54:00
+resolvedWhen: 2020-06-13 16:54:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,5 +1,5 @@
 # German language file for cState
-# Version 4.1
+# Version 4.4
 
 - id: languageCode
   translation: de

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -139,9 +139,21 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Zurzeit, basierend auf Durchschnittsdaten, sieht es so aus, als ob dieses System für ungefähr
 - id: averageSystemsDowntimeSecondPart
   translation: Minuten ausfällt.
+
+
+##
+## v4.4
+##
+
+- id: in
+  translation: in
+- id: weeksAgo
+  translation: " Wochen." # has to include space
+- id: yearAgo
+  translation: " Jahre"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,6 +1,6 @@
 # English language file for cState
 # Official
-# Version 4.1
+# Version 4.4
 
 - id: languageCode
   translation: en

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -141,7 +141,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Recently, based on average data, it looks like this system has gone down for about
@@ -156,6 +156,6 @@
 - id: in
   translation: in
 - id: weeksAgo
-  translation: "w"
+  translation: " w"
 - id: yearAgo
-  translation: " metus"
+  translation: " year"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -147,3 +147,15 @@
   translation: Recently, based on average data, it looks like this system has gone down for about
 - id: averageSystemsDowntimeSecondPart
   translation: minutes at a time.
+
+
+##
+## v4.4
+##
+
+- id: in
+  translation: in
+- id: weeksAgo
+  translation: "w"
+- id: yearAgo
+  translation: " metus"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,5 +1,5 @@
 # French language file for cState
-# Version 3.0
+# Version 4.4
 
 - id: languageCode
   translation: fr
@@ -16,7 +16,7 @@
 - id: isDown
   translation: Nous faisons face à des problèmes majeurs
 - id: isDisrupted
-  translation: Nous faisons face à des pertubations
+  translation: Nous faisons face à des perturbations
 - id: isNotice
   translation: Merci de lire le détail
 - id: isOk
@@ -31,7 +31,7 @@
   translation: pour améliorer votre expérience sur ce site Web.
 
 - id: thisIsDown
-  translation: Éteint
+  translation: Arrêté
 - id: thisIsDisrupted
   translation: Perturbé
 - id: thisIsNotice
@@ -41,9 +41,9 @@
 
 # "Last checked" + "just now"
 - id: lastChecked
-  translation: Dernière vérification
+  translation: Dernière vérification il y a # instead of someTimeAgo
 - id: justNow
-  translation: Il y a quelques secondes
+  translation: quelques secondes
 #- id: someTimeAgo
 #  translation: # Unable to translate
 
@@ -89,7 +89,7 @@
 - id: calmBeforeTheStorm
   translation: Est-ce le calme avant la tempête ?
 - id: noIncidentsDesc
-  translation: Cette page d'état ne contient aucun incident enregistré. Cela peut être dû au fait que le ou les propriétaires de la page d'état ont récemment configuré leur page d'état, n'ont eu aucun temps d'arrêt ou n'ont enregistré aucun temps d'arrêt.
+  translation: Cette page d'état ne contient aucun incident enregistré. Ce peut être car la page d'état vient d'être configurée, car il n'y a eu aucun temps d'arrêt ou car aucun n'a été enregistré.
 
 
 - id: continueReading
@@ -113,7 +113,7 @@
 - id: notFound
   translation: Il n'y a rien ici.
 - id: notFoundText
-  translation: Cela pourrait être un problème de notre part. Peut-être avons-nous déplacé une certaine ressource et maintenant elle a disparu. Il est également possible que la ressource que vous essayez de visualiser soit vide. Mais cela vous dérange-t-il aussi de vérifier le lien ?
+  translation: C'est peut-être une erreur de notre part. Peut-être avons-nous déplacé une certaine ressource, ce qui l'a rendu indisponible. Il est également possible que la ressource que vous essayez de visualiser soit vide. Avez-vous pris le temps de vérifier le lien ?
 
 - id: rss
   translation: S'abonner via RSS
@@ -122,7 +122,7 @@
 - id: or
   translation: ou
 - id: onlyThisFeed
-  translation: seulement ce flux
+  translation: seulement à ce flux
 
 ##
 ## v3
@@ -137,3 +137,23 @@
 ##
 - id: notFoundAffected
   translation: Il semble que ce système n'existe pas ou qu'il n'a jamais eu de temps d'arrêt enregistré.
+
+##
+## v4.1
+## 
+
+- id: averageSystemsDowntime
+  translation: D'après les données moyennes, il semble que ce système ait été indisponible pendant environ
+- id: averageSystemsDowntimeSecondPart
+  translation: minutes.
+
+##
+## v4.4
+##
+
+- id: in
+  translation: dans
+- id: weeksAgo
+  translation: " sem"
+- id: yearAgo
+  translation: " années"

--- a/i18n/lt.yaml
+++ b/i18n/lt.yaml
@@ -1,6 +1,6 @@
 # Lithuanian language file for cState
 # Official
-# Version 4.1
+# Version 4.4
 
 - id: languageCode
   translation: en

--- a/i18n/lt.yaml
+++ b/i18n/lt.yaml
@@ -147,3 +147,15 @@
   translation: Pastaruoju metu, regis, šis komponentas sutrikimų metu neveikia apie
 - id: averageSystemsDowntimeSecondPart
   translation: min.
+
+
+##
+## v4.4
+##
+
+- id: in
+  translation: in
+- id: weeksAgo
+  translation: " sav." # has to include space
+- id: yearAgo
+  translation: " metus"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,0 +1,157 @@
+# English language file for cState
+# Official
+# Version 4.1
+
+- id: languageCode
+  translation: nl
+- id: languageName
+  translation: Dutch
+- id: languageNameShort
+  translation: NL
+
+##
+## INDEX.HTML
+##
+
+# Summary status message
+- id: isDown
+  translation: Er zijn grote problemen
+- id: isDisrupted
+  translation: Er zijn onderbrekingen
+- id: isNotice
+  translation: Please read announcement
+- id: isOk
+  translation: Alle systemen werken
+
+# No JS warning
+- id: noScriptingIntro
+  translation: Uh oh! Het lijkt erop dat je javascript hebt uitgeschakeld.
+- id: noScriptingLink
+  translation: zet scripting aan
+- id: noScriptingOutro
+  translation: om je ervaring beter te maken.
+
+- id: thisIsDown
+  translation: Down
+- id: thisIsDisrupted
+  translation: Onderbroken
+- id: thisIsNotice
+  translation: Onderhoud
+- id: thisIsOk
+  translation: Operationeel
+
+# "Last checked" + "just now"
+- id: lastChecked
+  translation: Laatst gecontroleerd
+- id: justNow
+  translation: net
+- id: someTimeAgo
+  translation: geleden
+
+# Example usage: `5` + `years`
+# Final result: 'Last checked 5 years ago'
+# Number goes before string
+# Use short variants until months
+- id: yearsAgo
+  translation: jaren
+- id: monthsAgo
+  translation: maanden
+- id: daysAgo
+  translation: d
+- id: hoursAgo
+  translation: u
+- id: minsAgo
+  translation: min
+- id: secondsAgo
+  translation: s
+
+- id: autoRefreshNotice
+  translation: We herleden elke 5 minuten
+
+# Incidents
+- id: incidents
+  translation: Incidenten
+- id: incidentHistory
+  translation: Incident geschiedenis
+
+- id: resolved
+  translation: Opgelost # if it's less than a min
+- id: inUnderAMinute
+  translation: Binnen de minuut # continuing the last string
+- id: resolvedAfter
+  translation: Opgelost na # + 19 min
+- id: ofDowntime
+  translation: offline te zijn
+
+- id: downtimeOngoing
+  translation: Dit probleem is nog niet opgelost
+
+
+- id: calmBeforeTheStorm
+  translation: Is dit de stilte voor de storm?
+- id: noIncidentsDesc
+  translation: Deze status pagina heeft geen gelogde incidenten. Dit is misschien omdat de status pagina recent geinstaleerd is, er nog geen downtime is geweest, of nog geen downtime is gelogged.
+
+- id: continueReading
+  translation: Verder lezen
+- id: prev
+  translation: Vorige
+- id: next
+  translation: Volgende
+
+##
+## OTHER
+##
+
+- id: goBack
+  translation: Ga terug naar
+- id: backToTop
+  translation: terug naar top
+- id: poweredBy
+  translation: Powered by
+
+- id: notFound
+  translation: Hier is niets.
+- id: notFoundText
+  translation: Dit kan een fout zijn aan onze kant. Misschien hebben we de bron verplaats en nu is het weg. Het kan ook dat je de bron die je probeert te bekijken leeg is. Wil je mischien even de url checken?
+- id: rss
+  translation: Abonneer via RSS
+- id: toAllUpdates
+  translation: op alle updates
+- id: or
+  translation: or
+- id: onlyThisFeed
+  translation: enkel deze feed
+
+##
+## v3
+##
+- id: entries
+  translation: inzendingen
+- id: newestToOldest
+  translation: nieuwste naar oudste
+##
+## v4
+##
+- id: notFoundAffected
+  translation: Het lijkt erop dat het systeem niet bestaat of geen opgenomen downtime heeft.
+
+##
+## v4.1
+## 
+
+- id: averageSystemsDowntime
+  translation: Recentelijk, gebaseerd op gemiddelde downtime, is het systeem ofline geweest voor ongeveer
+- id: averageSystemsDowntimeSecondPart
+  translation: minuten per keer.
+
+##
+## v4.4
+##
+
+- id: in
+  translation: binnen
+- id: weeksAgo
+  translation: " w"
+- id: yearAgo
+  translation: " jaar"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,5 +1,4 @@
 # Dutch language file for cState
-# Official
 # Version 4.4
 
 - id: languageCode

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,6 +1,6 @@
-# English language file for cState
+# Dutch language file for cState
 # Official
-# Version 4.1
+# Version 4.4
 
 - id: languageCode
   translation: nl

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -1,0 +1,159 @@
+# Portuguese language file for cState
+# Version 4.4
+
+- id: languageCode
+  translation: pt
+- id: languageName
+  translation: Portuguese
+- id: languageNameShort
+  translation: POR
+
+##
+## INDEX.HTML
+##
+
+# Summary status message
+- id: isDown
+  translation: Enfrentando problemas importantes
+- id: isDisrupted
+  translation: Enfrentando disruipções
+- id: isNotice
+  translation: Por favor leia o anúncio
+- id: isOk
+  translation: Todos os sistemas operacionais
+
+# No JS warning
+- id: noScriptingIntro
+  translation: Uh oh! Parece que você desabilitou o JavaScript! Por favor
+- id: noScriptingLink
+  translation: habilitar scripts
+- id: noScriptingOutro
+  translation: para aprimorar sua experiência neste site.
+
+- id: thisIsDown
+  translation: Baixo
+- id: thisIsDisrupted
+  translation: Interrompido
+- id: thisIsNotice
+  translation: Manutenção
+- id: thisIsOk
+  translation: Funcionando
+
+# "Last checked" + "just now"
+- id: lastChecked
+  translation: Última verificação
+- id: justNow
+  translation: Agora mesmo
+- id: someTimeAgo
+  translation: Anteriormente
+
+# Example usage: `5` + `years`
+# Final result: 'Last checked 5 years ago'
+# Number goes before string
+# Use short variants until months
+- id: yearsAgo
+  translation: anos
+- id: monthsAgo
+  translation: meses
+- id: daysAgo
+  translation: d
+- id: hoursAgo
+  translation: h
+- id: minsAgo
+  translation: min
+- id: secondsAgo
+  translation: s
+
+- id: autoRefreshNotice
+  translation: Nós vamos tentar atualizar a cada 5 minutos
+
+# Incidents
+- id: incidents
+  translation: Incidentes
+- id: incidentHistory
+  translation: Histórico de incidentes
+
+- id: resolved
+  translation: Resolvido # if it's less than a min
+- id: inUnderAMinute
+  translation: em menos de um minuto # continuing the last string
+- id: resolvedAfter
+  translation: Resolvido depois # + 19 min
+- id: ofDowntime
+  translation: tempo de inatividade
+
+- id: downtimeOngoing
+  translation: Esse problema ainda não foi resolvido
+
+
+- id: calmBeforeTheStorm
+  translation: Isso é a calma após a tempestade?
+- id: noIncidentsDesc
+  translation: Essa página de status não possui incidentes registrados. Isso pode ocorrer porque o proprietário (ou proprietários) da página de status configurou recentemente sua página de status, não teve nenhu tempo de inatividade ou não registrou nenhum tempo de inatividade.
+
+
+- id: continueReading
+  translation: Continuar leitura
+- id: prev
+  translation: Anterior
+- id: next
+  translation: Próximo
+
+##
+## OTHER
+##
+
+- id: goBack
+  translation: Voltar para
+- id: backToTop
+  translation: Voltar ao topo
+- id: poweredBy
+  translation: Distribuído por
+
+- id: notFound
+  translation: Não há nada aqui.
+- id: notFoundText
+  translation: Isso pode ser um problema da nossa parte. Talvez tenhamos movido um determinado recurso e agora ele se foi. Também é possível que o recurso que você está tentando visualizar esteja vazio. Mas você se importa de verificar o link?
+
+- id: rss
+  translation: Se increva via RSS
+- id: toAllUpdates
+  translation: para todas as atualizações
+- id: or
+  translation: ou
+- id: onlyThisFeed
+  translation: só para esse feed
+
+##
+## v3
+##
+- id: entries
+  translation: entradas
+- id: newestToOldest
+  translation: do mais novo para o mais antigo
+
+##
+## v4
+##
+- id: notFoundAffected
+  translation: Parece que o sistema não existe ou nunca teve nenhum tempo de inatividade registrado.
+
+##
+## v4.1
+## 
+
+- id: averageSystemsDowntime
+  translation: Recentemente, por dados médicos para que esse sistema caiu por
+- id: averageSystemsDowntimeSecondPart
+  translation: minutos em uma hora.
+
+##
+## v4.4
+##
+
+- id: in
+  translation: em
+- id: weeksAgo
+  translation: " semanas"
+- id: yearAgo
+  translation: " ano"

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -20,7 +20,7 @@
 
   <p><small>
     {{ range .Params.Affected }}
-      <a href="affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
+      <a href="{{ printf "/affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
     {{ end }}
   </small></p>
 

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -20,7 +20,7 @@
 
   <p><small>
     {{ range .Params.Affected }}
-      <a href="/affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
+      <a href="affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
     {{ end }}
   </small></p>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 {{ if .Site.Params.useLargeHeaderDesign }}
 <div class="header header--large">
   <div class="contain contain--more center">
-    <a href="/" class="header__logo">
+    <a href="{{ .Site.BaseURL }}" class="header__logo">
       {{ if .Site.Params.useLogo }}
         <img src="{{ .Site.Params.logo }}" alt="{{ .Site.Title }}">
           {{ else }}
@@ -17,7 +17,7 @@
 {{ else }}
 <div class="header">
   <div class="contain">
-    <a href="/" class="header__logo header__logo--small">
+    <a href="{{ .Site.BaseURL }}" class="header__logo header__logo--small">
       {{ if .Site.Params.useLogo }}
         <img src="{{ .Site.Params.logo }}" alt="{{ .Site.Title }}">
           {{ else }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
   <div class="contain contain--more center">
     <a href="{{ .Site.BaseURL }}" class="header__logo">
       {{ if .Site.Params.useLogo }}
-        <img src="{{ .Site.Params.logo }}" alt="{{ .Site.Title }}">
+        <img src="{{ relURL .Site.Params.logo }}" alt="{{ .Site.Title }}">
           {{ else }}
         <h1>{{ .Site.Title }}</h1>
       {{ end }}
@@ -19,7 +19,7 @@
   <div class="contain">
     <a href="{{ .Site.BaseURL }}" class="header__logo header__logo--small">
       {{ if .Site.Params.useLogo }}
-        <img src="{{ .Site.Params.logo }}" alt="{{ .Site.Title }}">
+        <img src="{{ relURL .Site.Params.logo }}" alt="{{ .Site.Title }}">
           {{ else }}
         <h1>{{ .Site.Title }}</h1>
       {{ end }}

--- a/layouts/partials/index/announcements.html
+++ b/layouts/partials/index/announcements.html
@@ -6,12 +6,12 @@
     {{ range $active }}
       <div class="padding">
         <p>
-          <a href="{{ .Permalink }}"><strong class="bold">{{ .Title }} →</strong></a>
+          <a href="{{ .RelPermalink }}"><strong class="bold">{{ .Title }} →</strong></a>
         </p>
 
         <p><small>
           {{ range .Params.Affected }}
-            <a href="/affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
+            <a href="affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
           {{ end }}
         </small></p>
 

--- a/layouts/partials/index/announcements.html
+++ b/layouts/partials/index/announcements.html
@@ -11,7 +11,9 @@
 
         <p><small>
           {{ range .Params.Affected }}
-            <a href="affected/{{ . | urlize }}/" class="tag no-underline">{{ . }}</a>
+              
+          <a href="{{ printf "/affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+          
           {{ end }}
         </small></p>
 

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -59,7 +59,7 @@
         {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
         <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
-          <a href="/affected/{{ .name | urlize }}/" class="no-underline">
+          <a href="affected/{{ .name | urlize }}/" class="no-underline">
             {{ default .name .displayName }}
           </a>
 

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -59,7 +59,7 @@
         {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
         <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
-          <a href="affected/{{ .name | urlize }}/" class="no-underline">
+          <a href="{{ printf "/affected/%s/" (.name | urlize) | relURL }}" class="no-underline">
             {{ default .name .displayName }}
           </a>
 

--- a/layouts/partials/index/incidents-yearly.html
+++ b/layouts/partials/index/incidents-yearly.html
@@ -2,11 +2,10 @@
 
 
 {{ range ($incidents.GroupByDate "2006") }}
-  <div class="padding"></div>
-  <hr>
-  <p class="center" id="archive-{{ .Key }}"><a href="#archive-{{ .Key }}" class="no-underline"><strong>{{ .Key }}</strong>
+  
+  <p class="center archive__head" id="archive-{{ .Key }}"><a href="#archive-{{ .Key }}" class="no-underline"><strong>{{ .Key }}</strong>
     <span class="faded">({{ len .Pages }})</span>
-  </a></p><hr>
+  </a></p>
   
   {{ range .Pages }}
     {{ .Render "small" }}

--- a/layouts/partials/index/tabs.html
+++ b/layouts/partials/index/tabs.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.customTabs }}
   <div class="tabs">
     <div class="contain tabs--inner">
-      <a href="/#incidents" class="tab tab--current">
+      <a href="#incidents" class="tab tab--current">
         {{ T "incidents" }}
       </a>
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -295,6 +295,7 @@
     .issue h3 { line-height: 1.25; }
 
     .category__head { margin-top: 20px; }
+    .archive__head { padding: 20px; background: #f5f5f5; }
 
 
     /**
@@ -374,7 +375,7 @@
 
         .date { color: #c3bfb6; }
 
-        .tag { background-color: #1d1f20; }
+        .tag, .archive__head { background-color: #1d1f20; }
         .tag:hover { background: #222; }
         .issue:hover,
         .category__head:hover { background-color: #212121; }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -123,10 +123,12 @@ collections:
             default: 'en'
             options:
             - { label: "🇺🇸 English (default)", value: "en" }
-            - { label: "🇱🇹 Lithuanian (official)", value: "lt" }
+            - { label: "🇱🇹 Lietuviškai (official)", value: "lt" }
             - { label: "🇹🇷 Turkish", value: "tr" }
             - { label: "🇩🇪 Deutsch", value: "de" }
+            - { label: "🇳🇱 Dutch", value: "nl" }
             - { label: "🇫🇷 French", value: "fr" }
+            - { label: "🇧🇷 Portuguese", value: "pt"}
           - label: 'Site language in code for html[lang]'
             hint: 'Use the ISO 639-1 defined abbreviations. Examples: en, lt, de. Fully explained here: https://github.com/cstate/cstate/wiki/Customization#changing-site-language'
             name: 'languageCode'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -13,9 +13,10 @@ backend:
   name: git-gateway
 media_folder: "static/img"
 public_folder: "/img"
-display_url: /
+site_url: ../
+logo_url: https://raw.githubusercontent.com/cstate/cstate/master/images/cstate-logo-bg.svg
 
-# Do not change this!
+# Do not change this unless you know what you are doing!
 collections:
   - name: "issues"
     label: "Incidents"
@@ -24,11 +25,34 @@ collections:
     folder: "content/issues"
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    view_filters:
+      - label: Active (unresolved) issues
+        field: resolved
+        pattern: false
+      - label: 'Resolved issues'
+        field: resolved
+        pattern: true
+      - label: 'Informational posts'
+        field: informational
+        pattern: true
+      - label: Drafts
+        field: draft
+        pattern: true
+      - label: "High severity (down)"
+        field: severity
+        pattern: 'down'
+      - label: "Medium severity (disrupted)"
+        field: severity
+        pattern: 'disrupted'
+      - label: "Low severity (announcement)"
+        field: severity
+        pattern: 'announcement'
     fields:
       - {label: "Mark as incident", name: "section", widget: "hidden", default: "issue"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Start date & time (your time) ⌚", name: "date", widget: "datetime"}
       - {label: "Mark as resolved ✔", name: "resolved", widget: "boolean", required: false, default: false}
+      - {label: "Hide this from the site (make it a draft) 👀", name: "draft", widget: "boolean", required: false, default: false}
       - {label: "Mark as informational ℹ", name: "informational", widget: "boolean", required: false, default: false}
       - {label: "End date & time (your time) ⌛", name: "resolvedWhen", widget: "datetime", required: false}
       - label: "Affected systems (use exact name, separated by commas) 🧐"
@@ -55,6 +79,7 @@ collections:
     slug: "{{slug}}"
     fields:
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Hide this from the site (make it a draft) 👀", name: "draft", widget: "boolean", required: false, default: false}
       - {label: "Description for SEO and social media", name: "description", widget: "string", required: false}
       - label: "Markdown (or HTML) body"
         name: "body"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -38,6 +38,9 @@ collections:
       - label: Drafts
         field: draft
         pattern: true
+      - label: Published (not a draft)
+        field: draft
+        pattern: false
       - label: "High severity (down)"
         field: severity
         pattern: 'down'
@@ -77,6 +80,13 @@ collections:
     folder: "content/pages"
     create: true
     slug: "{{slug}}"
+    view_filters:
+      - label: Drafts
+        field: draft
+        pattern: true
+      - label: Published (not a draft)
+        field: draft
+        pattern: false
     fields:
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Hide this from the site (make it a draft) 👀", name: "draft", widget: "boolean", required: false, default: false}


### PR DESCRIPTION
## Official Support for Non-Root Directories, Improved and New Translations, Improvements with Tracking Time, and More with Netlify CMS

Changelog:

* **Medium to high severity bugfix** #126 - support for non-root directories

* **Medium priority - new feature** You can now filter issues on Netlify CMS

![image](https://user-images.githubusercontent.com/11616378/90008627-527f2400-dca5-11ea-9b0d-6f8358f9f748.png)

* **Low to medium priority** You can now hide pages and issues by turning them into drafts on Netlify CMS (this is a native feature of Hugo)
* **Low priority - new feature** By default, there will now be a cState logo on the Netlify CMS login page as well as a "Go back to site" button on that same page. Also, the link to go back to the site should now be more reliable and work with non-root directories.
* **Default CSS change** The years in the yearly archive now look like blocks instead of things separated by lines in earlier versions. After:

![image](https://user-images.githubusercontent.com/11616378/90013926-df7aab00-dcae-11ea-82d9-0a5fb3b7b70d.png)

Before: 

![image](https://user-images.githubusercontent.com/11616378/90013954-ed303080-dcae-11ea-92b4-5835c6585ba5.png)

* **Added Dutch translation** #133 
* **Updated German translation** #132 
* **Updated French translations** #134
* **Added Portugese translation** #136 
