### PR TITLE
135 relative times

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -124,7 +124,7 @@ params:
     - name: North Coast
       description: The main servers are located here.
       closed: true
-    - name: East Coast      
+    - name: East Coast
     - name: Uncategorized
       untitled: true
 
@@ -156,6 +156,11 @@ params:
   # shortDateFormat Default: "15:04 — Jan 2"
   dateFormat: January 2, 2006 at 3:04 PM
   shortDateFormat: 15:04 — Jan 2
+
+  # If enabled, will display relative times for incident history and summaries instead of using dateFormat.
+  #
+  # Default: true
+  useRelativeTime: true
 
   # What header design should we use?
   #
@@ -277,7 +282,7 @@ params:
   # Default: `true`
   # BOOLEAN; `true`, `false`
   alwaysKeepBrandColor: true
-  
+
   # Introduced in v4.0.1 for consistent
   # site title text color.
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -162,6 +162,11 @@ params:
   # Default: true
   useRelativeTime: true
 
+  # If enabled, doesn't show seconds on relative times.
+  #
+  # Default: false
+  skipSeconds: false
+
   # What header design should we use?
   #
   # Default: true

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -159,17 +159,17 @@ params:
 
   # If enabled, will display relative times for incident history and summaries instead of using dateFormat.
   #
-  # Default: true
+  # Default: `true`
   useRelativeTime: true
 
   # If enabled, doesn't show seconds on relative times.
   #
-  # Default: false
+  # Default: `false`
   skipSeconds: false
 
   # What header design should we use?
   #
-  # Default: true
+  # Default: `true`
   # BOOLEAN; `true`, `false`
   useLargeHeaderDesign: false
 
@@ -212,7 +212,7 @@ params:
   # Should we show the logo or the title
   # of the status page?
   #
-  # Default: false
+  # Default: `false`
   # BOOLEAN; `true`, `false`
   useLogo: true
 
@@ -249,7 +249,7 @@ params:
   # for average downtime on
   # systems ("/affected/") pages
   #
-  # Default: false
+  # Default: `false`
   # BOOLEAN; `true`, `false`
   disableComplexCalculations: false
 

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -8,7 +8,7 @@
 <a href="{{ .Permalink }}" class="issue no-underline">
   {{ if .Params.informational }}
 
-  <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
+  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
@@ -23,7 +23,7 @@
     </span>
 
   {{ else if .Params.Resolved }}
-    <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
+  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
@@ -67,7 +67,7 @@
     {{ end }}
   {{ else }}
 
-    <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
+  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -7,8 +7,8 @@
 
 <a href="{{ .Permalink }}" class="issue no-underline">
   {{ if .Params.informational }}
-    
-    <small class="date float-right">
+
+  <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
@@ -21,9 +21,9 @@
     </h3>
     <span class="faded">{{ .Summary | truncate 200 }}
     </span>
-  
+
   {{ else if .Params.Resolved }}
-    <small class="date float-right">
+    <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
@@ -67,7 +67,7 @@
     {{ end }}
   {{ else }}
 
-    <small class="date float-right">
+    <small class="date float-right relative-time" title="{{ .Date.Format "02 Jan 2006 03:05:00 PM" }}">
       {{ if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
@@ -82,17 +82,17 @@
     <!-- Marker -->
     {{ if eq .Params.severity "notice" }}
       <strong class="warning">
-        ◆ 
+        ◆
         {{ T "downtimeOngoing" }}
       </strong>
     {{ else }}
       <strong class="error">
         {{ if eq .Params.severity "down" }}
-        ■ 
+        ■
         {{ else if eq .Params.severity "disrupted" }}
-        ▲ 
+        ▲
         {{ else }}
-        ◆ 
+        ◆
         {{ end }}
         {{ T "downtimeOngoing" }}
       </strong>

--- a/layouts/partials/index/summary.html
+++ b/layouts/partials/index/summary.html
@@ -20,5 +20,5 @@
     {{ end }}{{ end }}{{ end }}
   </strong>
 
-  <div class="summary__date clicky float-right relative-time" onclick="location.reload()" data-prefix="{{ T "lastChecked" }} "></div>
+  <div class="summary__date clicky float-right relative-time" onclick="location.reload()" data-time-prefix="{{ T "lastChecked" }} "></div>
 </div>

--- a/layouts/partials/index/summary.html
+++ b/layouts/partials/index/summary.html
@@ -20,5 +20,5 @@
     {{ end }}{{ end }}{{ end }}
   </strong>
 
-  <div class="summary__date clicky float-right" onclick="location.reload()"></div>
+  <div class="summary__date clicky float-right relative-time" onclick="location.reload()" data-prefix="{{ T "lastChecked" }} "></div>
 </div>

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -88,8 +88,8 @@
       lastUpdated.innerHTML = '{{ T "lastChecked" }} ' + timeSince(lastUpdate) + ' {{ T "someTimeAgo" }}';
 
       // Refresh almost every 5m
-      if (lastUpdate > 290000) {
-        location.reload;
+      if (Math.floor(new Date() - lastUpdate) > 290000) {
+        location.reload();
       }
     }
   }, 5000)

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -67,7 +67,11 @@
     if (interval > 1) {
       return interval + ' {{ T "minsAgo" }}';
     }
-    return Math.floor(seconds) + '{{ T "secondsAgo" }}';
+    {{ if .Site.Params.skipSeconds }}
+      return '<1 {{ T "minsAgo" }}'
+    {{ else }}
+      return Math.floor(seconds) + '{{ T "secondsAgo" }}';
+    {{ end }}
   }
 
   /**

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -75,26 +75,30 @@
    * moves the timestamp to a title attribute tooltip.
    */
   function updateRelativeTimes() {
-    document.querySelectorAll('.relative-time')
-      .forEach(function(element) {
-        var time = Date.parse(element.getAttribute('title'));
-        var html = element.getAttribute('data-prefix') || '';
-        if (!time) {
-          time = element.innerText;
-          element.setAttribute('title', time || new Date);
-          html += '{{ T "justNow" }}';
-        } else {
-          html += timeSince(time) + ' {{ T "someTimeAgo" }}';
-        }
-        element.innerHTML = html.trim();
-      })
+    var elements = document.querySelectorAll('.relative-time');
+    for (var i = 0; i < elements.length; i++) {
+      var element = elements[i];
+      var time = Date.parse(element.getAttribute('title'));
+      var html = element.getAttribute('data-time-prefix') || '';
+      if (!time) {
+        time = element.innerText;
+        element.setAttribute('title', time || new Date);
+        html += '{{ T "justNow" }}';
+      } else {
+        html += timeSince(time) + ' {{ T "someTimeAgo" }}';
+      }
+      html += element.getAttribute('data-time-suffix') || '';
+      element.innerHTML = html.trim();
+    }
   }
   updateRelativeTimes();
   setInterval(updateRelativeTimes, 5000);
 
-  // Reload homepage eevery 290 seconds
+  /**
+   * Reload homepage after 290 seconds.
+   */
   if (document.querySelector('body.status-homepage')) {
-    setInterval(location.reload, 290000)
+    setTimeout(location.reload, 290000)
   }
 </script>
 

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -41,58 +41,61 @@
   }
 
   /**
-   * Timer
+   * Returns a relative date string for the given date.
    */
+  function timeSince(date) {
+    var seconds = Math.floor((new Date() - date) / 1000);
 
-  function hasClass(element, className) {
-    return (' ' + element.className + ' ').indexOf(' ' + className+ ' ') > -1;
+    var interval = Math.floor(seconds / 31536000);
+
+    if (interval > 1) {
+      return interval + ' {{ T "yearsAgo" }}';
+    }
+    interval = Math.floor(seconds / 2592000);
+    if (interval > 1) {
+      return interval + ' {{ T "monthsAgo" }}';
+    }
+    interval = Math.floor(seconds / 86400);
+    if (interval > 1) {
+      return interval + '{{ T "daysAgo" }}';
+    }
+    interval = Math.floor(seconds / 3600);
+    if (interval > 1) {
+      return interval + '{{ T "hoursAgo" }}';
+    }
+    interval = Math.floor(seconds / 60);
+    if (interval > 1) {
+      return interval + ' {{ T "minsAgo" }}';
+    }
+    return Math.floor(seconds) + '{{ T "secondsAgo" }}';
   }
 
-  if (hasClass(document.querySelector('body'), 'status-homepage')) {
-    var lastUpdated = document.querySelector('.summary__date');
-    lastUpdated.innerHTML = '{{ T "lastChecked" }} {{ T "justNow" }}';
-
-    var lastUpdate = new Date();
-
-    function timeSince(date) {
-      var seconds = Math.floor((new Date() - date) / 1000);
-
-      var interval = Math.floor(seconds / 31536000);
-
-      if (interval > 1) {
-        return interval + ' {{ T "yearsAgo" }}';
-      }
-      interval = Math.floor(seconds / 2592000);
-      if (interval > 1) {
-        return interval + ' {{ T "monthsAgo" }}';
-      }
-      interval = Math.floor(seconds / 86400);
-      if (interval > 1) {
-        return interval + '{{ T "daysAgo" }}';
-      }
-      interval = Math.floor(seconds / 3600);
-      if (interval > 1) {
-        return interval + '{{ T "hoursAgo" }}';
-      }
-      interval = Math.floor(seconds / 60);
-      if (interval > 1) {
-        return interval + ' {{ T "minsAgo" }}';
-      }
-      return Math.floor(seconds) + '{{ T "secondsAgo" }}';
-    }
-    var aDay = 24*60*60*1000;
+  /**
+   * Changes elements with the class 'relative-time' into relative times and
+   * moves the timestamp to a title attribute tooltip.
+   */
+  function updateRelativeTimes() {
+    document.querySelectorAll('.relative-time')
+      .forEach(function(element) {
+        var time = Date.parse(element.getAttribute('title'));
+        var html = element.getAttribute('data-prefix') || '';
+        if (!time) {
+          time = element.innerText;
+          element.setAttribute('title', time || new Date);
+          html += '{{ T "justNow" }}';
+        } else {
+          html += timeSince(time) + ' {{ T "someTimeAgo" }}';
+        }
+        element.innerHTML = html.trim();
+      })
   }
+  updateRelativeTimes();
+  setInterval(updateRelativeTimes, 5000);
 
-  window.setInterval(function() {
-    if (hasClass(document.querySelector('body'), 'status-homepage')) {
-      lastUpdated.innerHTML = '{{ T "lastChecked" }} ' + timeSince(lastUpdate) + ' {{ T "someTimeAgo" }}';
-
-      // Refresh almost every 5m
-      if (Math.floor(new Date() - lastUpdate) > 290000) {
-        location.reload();
-      }
-    }
-  }, 5000)
+  // Reload homepage eevery 290 seconds
+  if (document.querySelector('body.status-homepage')) {
+    setInterval(location.reload, 290000)
+  }
 </script>
 
 


### PR DESCRIPTION
This PR adds support for relative timestamps using the existing `timeSince()` function to incident history and issue summaries, and shared with the Last checked logic too.

Enabling this is controlled by setting `.Site.Params.useRelativeTime` to true. I defaulted it on, we can easily turn it off if you think that's a better default.

I believe this Closes #128 primarily, but I also added `.Site.Params.skipSeconds` which I believe Closes #135.