### PR TITLE
Allow displaying times in users local timezone

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -157,6 +157,15 @@ params:
   dateFormat: January 2, 2006 at 3:04 PM
   shortDateFormat: 15:04 — Jan 2
 
+  # Should dates be in UTC or a users local timezone?
+  #
+  # Note: This will override "dateFormat" and "shortDateFormat" as the dates
+  # will now be rendered client-side by Javascript.
+  #
+  # Default: `false`
+  # BOOLEAN; `true`, `false`
+  useLocalTime: false
+
   # What header design should we use?
   #
   # Default: true

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -11,7 +11,9 @@
   </h1>
 
   <small class="date">
-    {{ if .Site.Params.dateFormat }}
+    {{ if .Site.Params.useLocalTime }}
+      {{ .Date.Format "2006-01-02T15:04:05Z" }}
+    {{ else if .Site.Params.dateFormat }}
       {{ .Date.Format .Site.Params.dateFormat }}
     {{ else }}
       {{ .Date.Format "January 2, 2006 at 3:04 PM" }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -5,11 +5,13 @@
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
-<a href="{{ .Permalink }}" class="issue no-underline">
+<a href="{{ .Permalink }}" class="issue no-underline" data-date="{{ .Date.Format "2006-01-02T15:04:05Z" }}">
   {{ if .Params.informational }}
     
     <small class="date float-right">
-      {{ if .Site.Params.dateFormat }}
+      {{ if .Site.Params.useLocalTime }}
+        {{ .Date.Format "2006-01-02T15:04:05Z" }}
+      {{ else if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
         {{ .Date.Format "January 2, 2006 at 3:04 PM" }}
@@ -24,7 +26,9 @@
   
   {{ else if .Params.Resolved }}
     <small class="date float-right">
-      {{ if .Site.Params.dateFormat }}
+      {{ if .Site.Params.useLocalTime }}
+        {{ .Date.Format "2006-01-02T15:04:05Z" }}
+      {{ else if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
         {{ .Date.Format "January 2, 2006 at 3:04 PM" }}
@@ -68,7 +72,9 @@
   {{ else }}
 
     <small class="date float-right">
-      {{ if .Site.Params.dateFormat }}
+      {{ if .Site.Params.useLocalTime }}
+        {{ .Date.Format "2006-01-02T15:04:05Z" }}
+      {{ else if .Site.Params.dateFormat }}
         {{ .Date.Format .Site.Params.dateFormat }}
       {{ else }}
         {{ .Date.Format "January 2, 2006 at 3:04 PM" }}

--- a/layouts/partials/index/incidents-monthly.html
+++ b/layouts/partials/index/incidents-monthly.html
@@ -2,28 +2,43 @@
 
 
 
-{{ range ($incidents.GroupByDate "1") }}
-  <div class="padding"></div>
-  <hr>
-  <p class="center" id="archive-{{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}-{{ .Key }}"><a href="#archive-{{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}-{{ .Key }}" class="no-underline">
-    <b>
-      <!-- Hugo requires a '0' in the month
-      which is why this check exists -->
-      {{ if gt .Key 9 }}
-        {{ $month := printf "2006-%s-02" .Key }}
-        {{ $monthDate := $month | time }}
-        {{ $monthDate.Format "January" }}
-      {{ else }}
-        {{ $month := printf "2006-0%s-02" .Key }}
-        {{ $monthDate := $month | time }}
-        {{ $monthDate.Format "January" }}
-      {{ end }}
-      {{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}
-    </b><small class="faded">({{ len .Pages }})</small>
-  </a></p>
-  <hr>
+{{ if .Site.Params.useLocalTime }}
+  <div class="page-template hidden">
+    <div class="padding"></div>
+    <hr>
+    <p class="page-anchor center"><a class="page-link no-underline">
+      <b class="page-date"></b><small class="page-count faded"></small>
+    </a></p>
+    <hr>
+  </div>
 
-  {{ range .Pages }}
+  {{ range $incidents }}
     {{ .Render "small" }}
+  {{ end }}
+{{ else }}
+  {{ range ($incidents.GroupByDate "1") }}
+    <div class="padding"></div>
+    <hr>
+    <p class="center" id="archive-{{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}-{{ .Key }}"><a href="#archive-{{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}-{{ .Key }}" class="no-underline">
+      <b>
+        <!-- Hugo requires a '0' in the month
+        which is why this check exists -->
+        {{ if gt .Key 9 }}
+          {{ $month := printf "2006-%s-02" .Key }}
+          {{ $monthDate := $month | time }}
+          {{ $monthDate.Format "January" }}
+        {{ else }}
+          {{ $month := printf "2006-0%s-02" .Key }}
+          {{ $monthDate := $month | time }}
+          {{ $monthDate.Format "January" }}
+        {{ end }}
+        {{ range first 1 .Pages }}{{ .Date.Format "2006" }}{{ end }}
+      </b><small class="faded">({{ len .Pages }})</small>
+    </a></p>
+    <hr>
+
+    {{ range .Pages }}
+      {{ .Render "small" }}
+    {{ end }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/index/incidents-yearly.html
+++ b/layouts/partials/index/incidents-yearly.html
@@ -1,13 +1,25 @@
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
 
 
-{{ range ($incidents.GroupByDate "2006") }}
-  
-  <p class="center archive__head" id="archive-{{ .Key }}"><a href="#archive-{{ .Key }}" class="no-underline"><strong>{{ .Key }}</strong>
-    <span class="faded">({{ len .Pages }})</span>
-  </a></p>
-  
-  {{ range .Pages }}
+{{ if .Site.Params.useLocalTime }}
+  <div class="page-template hidden">
+    <p class="center page-anchor archive__head"><a class="page-link no-underline"><strong class="page-date"></strong>
+      <span class="page-count faded"></span>
+    </a></p>
+  </div>
+
+  {{ range $incidents }}
     {{ .Render "small" }}
+  {{ end }}
+{{ else }}
+  {{ range ($incidents.GroupByDate "2006") }}
+
+    <p class="center archive__head" id="archive-{{ .Key }}"><a href="#archive-{{ .Key }}" class="no-underline"><strong>{{ .Key }}</strong>
+      <span class="faded">({{ len .Pages }})</span>
+    </a></p>
+
+    {{ range .Pages }}
+      {{ .Render "small" }}
+    {{ end }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -95,6 +95,95 @@
   }, 5000)
 </script>
 
+{{ if .Site.Params.useLocalTime }}
+  <script type="text/javascript">
+    var dates = document.getElementsByClassName('date');
+    var options = {year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit"};
+
+    for (var i = 0; i < dates.length; i++) {
+      var el = dates.item(i);
+      var date = new Date(Date.parse(el.textContent.trim()));
+      el.textContent = date.toLocaleDateString(undefined, options);
+    }
+  </script>
+
+  <script type="text/javascript">
+    var dates = document.getElementsByClassName('short-date');
+    var options = {month: "short", day: "numeric", hour: "numeric", minute: "2-digit"};
+
+    for (var i = 0; i < dates.length; i++) {
+      var el = dates.item(i);
+      var date = new Date(Date.parse(el.textContent.trim()));
+      el.textContent = "("+date.toLocaleDateString(undefined, options)+")";
+    }
+  </script>
+
+  <script type="text/javascript">
+{{ if eq .Site.Params.incidentHistoryFormat "yearly" }}
+    function getAnchor(date) { return date.getFullYear().toString() }
+    function getTitle(date) { return date.toLocaleDateString(undefined, {year: "numeric"}); }
+{{ else }}
+    function getAnchor(date) { return date.getFullYear().toString()+"-"+(date.getMonth() + 1).toString(); }
+    function getTitle(date) { return date.toLocaleDateString(undefined, {year: "numeric", month: "long"}); }
+{{ end }}
+
+    var incidentContainer = document.getElementById('incidents');
+    var template = incidentContainer.getElementsByClassName('page-template').item(0);
+
+    var currentCategory = undefined;
+    var currentCount = 0;
+    var currentHeader = undefined;
+
+    function cloneHeader(beforeElement, date) {
+      var date = new Date(Date.parse(child.getAttribute("data-date")));
+
+      var header = template.cloneNode(true);
+      header.classList.remove("hidden");
+
+      header.getElementsByClassName("page-date")[0].textContent = getTitle(date);
+
+      var anchor = "archive-"+getAnchor(date);
+      header.getElementsByClassName("page-anchor")[0].id = anchor;
+      header.getElementsByClassName("page-link")[0].setAttribute("href", "#"+anchor);
+
+      return header
+    }
+
+    for (var i = 0; i < incidentContainer.children.length; i++) {
+      var child = incidentContainer.children.item(i);
+      if (!child.classList.contains("issue")) {
+        continue;
+      }
+
+      var date = new Date(Date.parse(child.getAttribute("data-date")));
+      var category = getAnchor(date);
+
+      if (currentCategory === undefined) {
+        currentCategory = category;
+        currentHeader = cloneHeader(child, date);
+
+        // Increment "i" because we added an element to the incidentContainer
+        child.insertAdjacentElement("beforebegin", currentHeader);
+        i++;
+      } else if (category !== currentCategory) {
+        currentHeader.getElementsByClassName("page-count")[0].textContent = " ("+currentCount.toString()+")";
+
+        currentCategory = category;
+        currentCount = 0;
+        currentHeader = cloneHeader(child, date);
+
+        // Increment "i" because we added an element to the incidentContainer
+        child.insertAdjacentElement("beforebegin", currentHeader);
+        i++;
+      }
+
+      currentCount++;
+    }
+
+    currentHeader.getElementsByClassName("page-count")[0].textContent = " ("+currentCount.toString()+")";
+  </script>
+{{ end }}
+
 
 {{ if ne .Site.Params.googleAnalytics "UA-00000000-1" }}
   <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -112,6 +112,7 @@
     .padding-s { padding: 6px; }
     .padding { padding: 12px; }
     .clicky { cursor: pointer; }
+    .hidden { display: none; }
 
 
     /**

--- a/layouts/shortcodes/track.html
+++ b/layouts/shortcodes/track.html
@@ -1,5 +1,7 @@
-{{ if .Site.Params.dateFormat }}
-  <span class="faded">({{ dateFormat .Site.Params.shortDateFormat (.Get 0) }})</span>
+{{ if .Site.Params.useLocalTime }}
+  <span class="short-date faded">{{ dateFormat "2006-01-02T15:04:05Z" (.Get 0) }}</span>
+{{ else if .Site.Params.dateFormat }}
+  <span class="short-date faded">({{ dateFormat .Site.Params.shortDateFormat (.Get 0) }})</span>
 {{ else }}
-  <span class="faded">({{ dateFormat "15:04 — Jan 2" (.Get 0) }})</span>
+  <span class="short-date faded">({{ dateFormat "15:04 — Jan 2" (.Get 0) }})</span>
 {{ end }}


### PR DESCRIPTION
This commit adds a new config parameter, `useLocalTime` (defaulted to `false` for backwards compatibility).

When set to `true`, cState will render all dates in the UI as ISO8601 dates and add some Javascript to update these dates to the users local timezone. This PR ensures the incident history grouping is also done in the users local timezone if enabled.

This change **only** applies to dates rendered in the UI, and not those in the JSON API, these remain in UTC time (though the PR does update the Hugo generation to explicitly use UTC dates).

One downside of altering the dates using Javascript to format the dates is that the `dateFormat` and `shortDateFormat` variables are no longer useful, as these are in the Golang-specific date format.

**Before, incident history:**
![image](https://user-images.githubusercontent.com/354845/99757763-c8fcaf00-2b3b-11eb-8c50-aaf05c6f4667.png)

**Before, specific incident:**
![image](https://user-images.githubusercontent.com/354845/99757878-15e08580-2b3c-11eb-8137-60e38b72a4a3.png)

**After, incident history (note, I'm in Australia / UTC+10):**
![image](https://user-images.githubusercontent.com/354845/99757800-dd40ac00-2b3b-11eb-8eea-16ac92ecd1ef.png)

**After, specific incident:**
![image](https://user-images.githubusercontent.com/354845/99757925-2a248280-2b3c-11eb-9a7e-ecf3aab58a3c.png)

closes #123