### PR TITLE
Docker: entrypoint script fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,12 @@ WORKDIR /cstate
 # Install hugo & git
 RUN apk add --no-cache hugo git
 
-# -- First Run --
-
 # Download the example site
-RUN git clone https://github.com/cstate/example /cstate
+RUN git clone -b master --depth=1 https://github.com/cstate/example /cstate
 
 # Copy files from this repo into themes/cstate
 RUN mkdir -p /cstate/themes/cstate
 COPY . /cstate/themes/cstate
 
-# Prepare the entrypoint files
+# Copy entrypoint script into the container image, this runs everytime the container cold-starts.
 COPY ./docker/entrypoint.sh /docker-entrypoint.d/10-build-hugo.sh

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can also support the creator of this project by **starring, sharing, and usi
 * [**Example site — cstate.mnts.lt**](https://cstate.mnts.lt)
 * [Source code of the example cState site](https://github.com/cstate/example)
 
+*Thank you to [Netlify](https://www.netlify.com) for hosting our demo websites!*
+
 ### More examples from the internet
 
 * [Chocolatey](https://status.chocolatey.org/)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,23 @@
 WORK_DIR="/app"
 SRC_DIR="/cstate"
 
+echo "[CSTATE-DOCKER] Initalising container..."
+
 # Check if the working dir is empty, if it is we'll need to copy
 # the files in from src directory (usually /cstate)
 if ! [ "$(ls -A $WORK_DIR)" ]; then
     # First run, copy cstate's files in.
-    echo "First time run! Hello, World :)"
+    echo "[CSTATE-DOCKER] Copying cState into staging area. First Start."
     cp -R $SRC_DIR/* $WORK_DIR
 fi
 
-# Continue with building
-
-# CD into working dir
-cd /app
+cd $WORK_DIR
 
 # Build the hugo site
+echo "[CSTATE-DOCKER] Running hugo build service..."
 hugo
 
 # Copy built files into NGINX directory
-cp -r /app/public/* /usr/share/nginx/html
+cp -r /$WORK_DIR/public/* /usr/share/nginx/html
+
+echo "[CSTATE-DOCKER] Initalisation complete."


### PR DESCRIPTION
## Overview

This PR should resolve #160 - the issue seems to be with the entrypoint being encoded with CRLF line endings, I've also added some extra debugging messages to the entrypoint script, to make diagnosing future Docker-related issues easier.

I'd also like to suggest building the cState Dockerfile into an image and publishing it on Docker Hub or GitHub Packages for ease of deployment. This would also make a docker-compose.yaml file possible (or at least, more user friendly). GitHub Actions are able to build the images, it doesn't take long as we're only compiling the site with Hugo at run-time.

I've also updated the Dockerfile to only clone the master branch of cstate/example, and only get the latest commit - this will hopefully improve the build speed of the image.

## Changes to Documentation

I'd also like to suggest the following updates to the deploying with Docker wiki page.

```md
# Installing cState with Docker

cState can run on Docker for both production and development purposes. 

## Building the Image

cState (currently) doesn't have a publicly built image, so it must be built manually. You can do this on any machine that has
Docker and Git installed.

1. Clone the main cState repository: `git clone https://github.com/cstate/cstate`
2. Navigate to the cState directory: `cd cstate`
3. Build the image: `docker build -t cstate .` (note: you can add :[version] after cState if you wish to have multiple versions of cState available).


## Run the Container

Once you've built (or pulled) the container, you can run cState. 

`docker run -p 8080:80 --name=cstate -v /var/cstate:/app cstate`

> You can replace 8080 with any other port, this is where cState will listen on the host computer.

> You can replace /var/cstate with any other path, this is where cState's files will be stored, the user managing cState will need access to this directory. 

## Reloading Modifications

Once files have been modified locally, the site must be rebuilt with Hugo. The easiest way to do this is to simply restart the container.

`docker restart cstate`

If restarting the container isn't a possibility, you can manually run hugo with docker exec

\`\`\`
docker exec -it cstate /bin/ash
cd /app
hugo
cp -r /app/public/* /usr/share/nginx/html
\`\`\`

```

## Footnotes

I have some plans for the dockerfile, such as making reloading the files easier (a script that can be executed via docker exec instead of requiring the user to drop into a shell?) - but I'll bring these up in their own issue in due course.

I've based this PR from the master branch as cState currently doesn't build from the dev branch, but I can rebase it if required.
