### PR TITLE
clarify what doesn't work as a baseURL

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -89,7 +89,14 @@ defaultContentLanguage: en
 # version 3. If you are just testing,
 # localhost should automatically work.
 #
-# Example: https://status.example.com/
+# Example: 
+# baseUrl: https://status.example.com/
+#
+# For testing:
+# baseUrl: http://localhost
+#
+# Broken example:
+# baseUrl: /
 baseURL: https://cstate.mnts.lt
 
 ############################################################


### PR DESCRIPTION
I was confused when reading the sample config file, as explained in #164. "don't support /" could have meant a trailing slash, or subdirectories, or at least wasn't exactly clear to me. By adding an explicit example of a broken behavior, we make it clear what we're talking about here, and what to avoid.

Closes #164 
