### PR TITLE
Allow cross origin on Vercel deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can also support the creator of this project by **starring, sharing, and usi
 * [**Example site — cstate.mnts.lt**](https://cstate.mnts.lt)
 * [Source code of the example cState site](https://github.com/cstate/example)
 
+*Thank you to [Netlify](https://www.netlify.com) for hosting our demo websites!*
+
 ### More examples from the internet
 
 * [Chocolatey](https://status.chocolatey.org/)

--- a/exampleSite/vercel.json
+++ b/exampleSite/vercel.json
@@ -1,0 +1,12 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I created a vercel.json file, which is their equivalent of a netlify.toml file. This will allow cross origin requests.