### PR TITLE
Remove Storehouse from the README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You can also support the creator of this project by **starring, sharing, using c
 * [sr.ht](https://status.sr.ht/)
 * [Content Ignite](https://status.contentignite.com/)
 * [FSCI](https://status.fsci.in/)
-* [Storehouse](https://status.sthse.co)
 * [Hyrousek](https://status.hyrousek.tk)
 * [josh.win](https://status.josh.win)
 


### PR DESCRIPTION
Their status page is no longer present, as they seem to be changing their business model entirely.