### PR TITLE
cState v5.0.5

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,6 +1,6 @@
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}{{ $active := where $incidents "Params.resolved" "=" false }}{{ $isNotice := where $active "Params.severity" "=" "notice" }}{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}{{ $isDown := where $active "Params.severity" "=" "down" }}{
   "is": "index",
-  "cStateVersion": "5.0.4",
+  "cStateVersion": "5.0.5",
   "apiVersion": "2.0",
   "title": "{{ .Site.Title }}",
   "languageCodeHTML": "{{ .Site.LanguageCode }}",

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -3,7 +3,7 @@
    * Dev toolset
    */
 
-  console.log('cState v5.0.4 - https://github.com/cstate/cstate');
+  console.log('cState v5.0.5 - https://github.com/cstate/cstate');
   document.getElementsByTagName('html')[0].className = 'js';
 
   /**

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -12,7 +12,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
-    <meta name="generator" content="cState v5.0.4 - https://github.com/cstate/cstate">
+    <meta name="generator" content="cState v5.0.5 - https://github.com/cstate/cstate">
     <meta name="theme-color" content="{{ .Site.Params.brand }}">
     <script>
     var themeBrandColor = '{{ .Site.Params.brand }}';


### PR DESCRIPTION
v5.0.5 includes:

- #199 the date for future issues is shown instead of "ongoing" which is confusing if it hasn't even started

This has prompted a discussion about maintenance issues and how to make them work better which will be addressed in a future release.

- #204 this release also fixes an invalid JSON template
- typo fixes by community members

The updates in this release were pushed to the master branch earlier but didn't receive an official release (meaning you could have a v5.0.4 release which was compiled from different source code depending on where you found it). This update is official and will show up as v5.0.5 when checked in console and all the other usual places.

This repo is starred by 1425 people as of midnight October 1st. Make sure to read #207 and join Hacktoberfest 2021 by contributing your thoughts about how to improve cState!