### PR TITLE
cState v5.1

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -393,7 +393,6 @@ outputs:
     - html
     - json
     - rss
-    - svg
   home:
     - html
     - json
@@ -403,6 +402,7 @@ outputs:
     - html
     - json
     - rss
+    - svg
 
 outputFormats:
   svg:

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -393,6 +393,7 @@ outputs:
     - html
     - json
     - rss
+    - svg
   home:
     - html
     - json

--- a/layouts/_default/list.svg
+++ b/layouts/_default/list.svg
@@ -1,0 +1,44 @@
+{{ $incidents := where .Site.RegularPages "Params.section" "issue" -}}
+{{ $active := where $incidents "Params.resolved" "=" false -}}
+{{ $isNotice := where $active "Params.severity" "=" "notice" -}}
+{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" -}}
+{{ $isDown := where $active "Params.severity" "=" "down" -}}
+{{ $shield_prefix := .Site.Title -}}
+{{ $status_text := T "thisIsOk" -}}
+{{ $status_color := .Site.Params.ok -}}
+{{ if $isDown -}}
+  {{ $status_text = T "thisIsDown" -}}
+  {{ $status_color = .Site.Params.down -}}
+{{ else if $isDisrupted -}}
+  {{ $status_text = T "thisIsDisrupted" -}}
+  {{ $status_color = .Site.Params.disrupted -}}
+{{ else if $isNotice -}}
+  {{ $status_text = T "thisIsNotice" -}}
+  {{ $status_color = .Site.Params.notice -}}
+{{ end -}}
+{{ $text_padding := 1 -}}
+{{ $left_text_lenght := $shield_prefix | strings.RuneCount -}}
+{{ $right_text_length := $status_text | strings.RuneCount -}}
+{{ $left_text_padding := $text_padding -}}
+{{ $right_box_padding := add (mul $text_padding 2) $left_text_lenght -}}
+{{ $right_text_padding := add $right_box_padding $text_padding -}}
+{{ $total_width := add (mul $text_padding 4) (add $left_text_lenght $right_text_length) -}}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="2em" width="{{ $total_width }}ex" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="100%" height="100%" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)" fill="#fff" >
+    <rect x="0" y="0" width="100%" height="100%" fill="#555" />
+    <rect x="{{ $right_box_padding }}ex" y="0" height="100%" width="100%" fill="{{ $status_color }}"/>
+    <rect x="0"  y="0" width="100%" height="100%" fill="url(#b)"/>
+    
+    <text x="{{ $left_text_padding }}ex" y="15" fill="#010101" fill-opacity=".3">{{ $shield_prefix }}</text>
+    <text x="{{ $left_text_padding }}ex" y="14">{{ $shield_prefix }}</text>
+    <text x="{{ $right_text_padding }}ex" y="15" fill="#010101" fill-opacity=".3">{{ $status_text }}</text>
+    <text x="{{ $right_text_padding }}ex" y="14">{{ $status_text }}</text>
+  </g>
+</svg>

--- a/layouts/_default/list.svg
+++ b/layouts/_default/list.svg
@@ -1,9 +1,9 @@
-{{ $incidents := where .Site.RegularPages "Params.section" "issue" -}}
+{{ $incidents := where .RegularPages "Params.section" "issue" -}}
 {{ $active := where $incidents "Params.resolved" "=" false -}}
 {{ $isNotice := where $active "Params.severity" "=" "notice" -}}
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" -}}
 {{ $isDown := where $active "Params.severity" "=" "down" -}}
-{{ $shield_prefix := .Site.Title -}}
+{{ $shield_prefix := .Title -}}
 {{ $status_text := T "thisIsOk" -}}
 {{ $status_color := .Site.Params.ok -}}
 {{ if $isDown -}}

--- a/layouts/affected/list.json
+++ b/layouts/affected/list.json
@@ -28,7 +28,7 @@
         "summary": {{ jsonify .Summary }}
       }
     {{ end }}{{ end }}
-  ], 
+  ]
 }
 
 

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,6 +1,6 @@
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}{{ $active := where $incidents "Params.resolved" "=" false }}{{ $isNotice := where $active "Params.severity" "=" "notice" }}{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}{{ $isDown := where $active "Params.severity" "=" "down" }}{
   "is": "index",
-  "cStateVersion": "5.0.5",
+  "cStateVersion": "5.1",
   "apiVersion": "2.0",
   "title": "{{ .Site.Title }}",
   "languageCodeHTML": "{{ .Site.LanguageCode }}",

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -3,7 +3,7 @@
    * Dev toolset
    */
 
-  console.log('cState v5.0.5 - https://github.com/cstate/cstate');
+  console.log('cState v5.1 - https://github.com/cstate/cstate');
   document.getElementsByTagName('html')[0].className = 'js';
 
   /**

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -12,7 +12,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
-    <meta name="generator" content="cState v5.0.5 - https://github.com/cstate/cstate">
+    <meta name="generator" content="cState v5.1 - https://github.com/cstate/cstate">
     <meta name="theme-color" content="{{ .Site.Params.brand }}">
     <script>
     var themeBrandColor = '{{ .Site.Params.brand }}';


### PR DESCRIPTION
Changelog:

Today we're celebrating Hacktoberfest with a critical bugfix to the JSON API so it works properly when checking _for a singular component status_ (unneeded `,` removed) and expanding 'shields' - SVG badges - to show status for ANY component as per a user suggestion - #208.

**You will need to change the config.yml file for this feature to be enabled. (If you use Netlify CMS, just update your site configuration and the SVG links for specific components will start working after the next deploy.)**

This is what your `outputs` should look like:

```

outputs:
  page:
    - html
    - json
  section:
    - html
    - json
    - rss
  home:
    - html
    - json
    - rss
    - svg
  term:
    - html
    - json
    - rss
    - svg
```

Notice that `svg` is now added to the bottom under `term` as well as `home`.

Once you've done that, go to `yourexamplesite.com/affected/api/index.svg` (or basically just click open the status page, click on one component (in this case it's API) and then add `/index.svg` to the end of the link.