### PR TITLE
Fix downtimeOngoing style inconsistencies

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -329,11 +329,13 @@ params:
   # disrupted: "#cc4400"
   # down: "#e60000"
   # notice: "#24478f"
+  # ongoing: "#cc4400"
   brand: "#0a0c0f"
   ok: "#008000"
   disrupted: "#cc4400"
   down: "#e60000"
   notice: "#24478f"
+  ongoing: "#cc4400"
 
   # If the status page shows that
   # there are disruptions or outages

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -80,7 +80,7 @@
     {{ end }}
   {{ end }}
   {{ else }}
-    <strong class="error">
+    <strong class="ongoing">
       {{ if eq .Params.severity "down" }}
       ■ 
       {{ else if eq .Params.severity "disrupted" }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -88,7 +88,7 @@
 
     <!-- Marker -->
     {{ if eq .Params.severity "notice" }}
-      <strong class="warning">
+      <strong class="ongoing">
         ◆
         {{ if .Date.Before now }}
           {{ T "downtimeOngoing" }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -100,6 +100,7 @@
     .ok { color: {{ .Site.Params.ok }}; }
     .warning { color: {{ .Site.Params.disrupted }}; }
     .error { color: {{ .Site.Params.down }}; }
+    .ongoing { color: {{ .Site.Params.ongoing }}; }
 
     .contain {
       max-width: 640px;


### PR DESCRIPTION
As described in #212 CSS classes applied to `downtimeOngoing` messages are not consistent through the different pages.

This PR aims to fix that by providing an additional class, allowing further customization.

closes #212 