### PR TITLE
External link button to link to a component

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -162,6 +162,10 @@ params:
       category: North Coast
     - name: Backup Gateway
       category: North Coast
+    - name: Website
+      description: The web frontend for the application.
+      category: Uncategorized
+      link: https://example.com/
     - name: API
       description: The guts of the application.
       category: Uncategorized

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -65,6 +65,14 @@
             </span>
           {{ end }}
 
+          {{ with .link }}
+            <span class="span-icon">
+              <a href="{{ . }}" class="link-style">
+                🔗
+              </a>
+            </span>
+          {{ end }}
+
           <span class="component-status">
             {{ if $thisIsDown }}
               {{ T "thisIsDown" }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -115,6 +115,11 @@
     .padding { padding: 12px; }
     .clicky { cursor: pointer; }
 
+    .link-style { border: none; }
+    .span-icon {
+      float: right;
+      margin-left: 16px;
+    }
 
     /**
      * Categories


### PR DESCRIPTION
Discussion previously occurred in #214 

This PR adds a new optional field to components in config.yml for an external url. The intent of this change is to allow cstate administrators to directly link to services/components that have web frontends.

<img src="https://user-images.githubusercontent.com/18688190/147494474-fa4a696f-c25e-4212-9abc-0b1af577717f.png" width="700">

Based on [conversation](https://github.com/cstate/cstate/issues/214#issuecomment-981752806) with @mistermantas, the `🔗` unicode character was chosen to represent the link as the only candidate that consistently rendered across all browsers.

Alternatives previously considered:
```
🡭 U+1F86D
🡵 U+1F875
🢅 U+1F885
```

**Test plan**

The change can be enabled or disabled by specifying or omitting the newly added field `link`. I have enabled it by default for a new component in exampleSite/config.yml to demonstrate its existence to new users.
```yaml
...
  systems:
    - name: Website
      description: The web frontend for the application.
      category: Uncategorized
      link: https://example.com/
```

I have tested the change on Linux and verified the chosen character is easily visible in both light and dark mode on the browser I have available. I am requesting a reviewer with a machine with IE please verify the IE8 compatibility, thank you. It also renders correctly in a mobile browser.

|   | light  |   dark |  
|---|---|---|
| Chrome  | ✅  | ✅  |
| Firefox  | ✅  | ✅  |
| Mac (safari?)  | ✅  | ✅  |
| IE8 | ❓ |❓  | 

**Documentation changes**

Since I cannot include the wiki update as part of the PR, I have included the edited section in this [gist](https://gist.github.com/aperullo/bc173f15ce4ba33325f634408d179696).

Closes #214 
