### PR TITLE
layout: use simple arrows as list pagination icons

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -76,12 +76,12 @@
           <div class="center">
             {{ if $paginator.HasPrev }}
               <a href="{{ $paginator.Prev.URL }}#incidents">
-                ⭠ &nbsp;
+                ← &nbsp;
                 {{ T "prev" }}
               </a>
             {{ else }}
               <span class="faded">
-                ⭠ &nbsp;
+                ← &nbsp;
                 {{ T "prev" }}
               </span>
             {{ end }}
@@ -97,12 +97,12 @@
             {{ if $paginator.HasNext }}
               <a href="{{ $paginator.Next.URL }}#incidents">
                 {{ T "next" }} &nbsp;
-                ⭢
+                →
               </a>
             {{ else }}
               <span class="faded">
                 {{ T "next" }} &nbsp;
-                ⭢
+                →
               </span>
             {{ end }}
           </div>

--- a/layouts/partials/index/incidents.html
+++ b/layouts/partials/index/incidents.html
@@ -27,12 +27,12 @@
     <div class="center">
       {{ if $paginator.HasPrev }}
         <a href="{{ $paginator.Prev.URL }}#incidents">
-          ⭠ &nbsp;
+          ← &nbsp;
           {{ T "prev" }}
         </a>
       {{ else }}
         <span class="faded">
-          ⭠ &nbsp;
+          ← &nbsp;
           {{ T "prev" }}
         </span>
       {{ end }}
@@ -48,12 +48,12 @@
       {{ if $paginator.HasNext }}
         <a href="{{ $paginator.Next.URL }}#incidents">
           {{ T "next" }} &nbsp;
-          ⭢
+          →
         </a>
       {{ else }}
         <span class="faded">
           {{ T "next" }} &nbsp;
-          ⭢
+          →
         </span>
       {{ end }}
     </div>


### PR DESCRIPTION
The currently used "triangle-headed" arrows are from the Unicode code
block "Supplemental Arrows-C" [1], which seems to be not widely
supported. This also applies to e.g. Roboto, which is being explicitly
used in the CSS.

Instead, use the "simple" arrows from the "Arrows" block, which is much
more widely supported by fonts.

[1]: https://en.wikipedia.org/wiki/Supplemental_Arrows-C

closes #242
