### PR TITLE
cState v5.5 Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ For this tutorial, it is assumed that you have Hugo and Git installed (check wit
 git clone --recursive -b master https://github.com/cstate/example.git
 ```
 
+You must use `--recursive` so that Git downloads cState and you do not have an empty `themes/cstate` folder.
+
 Now you can edit what's inside the folder (`cd example`) and try previewing that with this command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -79,71 +79,61 @@ There are other commercial options that may update faster because of their archi
 
 ## Getting started 💻
 
-This is how you create a **new site powered by cState.**  What you are generating is a Hugo site with specific, already existing modifications (to Hugo, cState is a theme).
+This is how you create a **new site powered by cState.**  What you are generating is a Hugo site with specific, already existing modifications (to Hugo, cState acts like a theme).
+
+**IF YOU ARE A DEVELOPER / WANT TO CONTRIBUTE TO THE DEVELOPMENT, SCROLL TO THE BOTTOM. THIS IS FOR USERS.**
  
+Aside from hosting the repository itself on Git (usually on GitHub), your next options are:
 
-### 💚 Netlify and Netlify CMS
+* **Site deployment platform:**
+    * Cloudflare Pages (recommended for larger teams)
+    * Netlify (recommended for most easy setup)
+    * GitHub Pages
+    * GitLab Pages
+    * Vercel
+    * render.com
+    * host it yourself
+* **Admin panels / CMS:**
+    * Forestry.io
+    * Netlify CMS
+    * Or just edit locally / use your Git provider's online editor (github.com, gitlab.com, etc)
 
-cState was built to work best with Netlify and comes with the neccesary files to enable Netlify CMS.
+You can also look at [other headless CMS options **(we use Git-based CMS types)** on jamstack.org](https://jamstack.org/headless-cms/).
 
-You don't have to use Netlify, but this is the best all-around option:
+### 🧡 Cloudflare Pages (GitHub Pages, render.com, Vercel, Forestry...)
 
-- To get you started, Netlify is **completely free** (you can pay for extra features, bandwidth, etc)
-- It supports all the features you'd want for hosting a modern website: **HTTPS, domain linking, worldwide asset serving, rollbacks, and more**
-- As you'd expect, **Netlify CMS** works best with Netlify. **It takes just a few clicks** to make it work
+If you wish to use Netlify, use the button below for easier deployment.
 
+All other static site generator platforms require you to follow this instruction:
 
-You can simply click this button to get started:
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cstate/example)
-
-This sets up cState with its default settings from the [the example repository](https://github.com/cstate/example) repo.
-
-If you cloned the example repository and want to use that newly forked repo, click the 'New site from Git' button in the user dashboard.
-
-These are the settings you should be using:
+1. Clone the repository cstate/example - [here is a link to do it on GitHub](https://github.com/cstate/example/generate)
+2. Go to pages.cloudflare.com and sign in
+3. Create a new site from Git, select your newly generated repository
+4. These are the settings you should be using:
 
 + Build command: **hugo**
 + Publish directory: **public**
 + Add one build environment variable
   + Key: **HUGO_VERSION**
-  + Value: **0.80** (or later)
-+ Also **for the Build image selection, pick Ubuntu Xenial 16.04 or later**
+  + Value: **0.101.0** (or later) 
 
-### 🧡 Other great hosting and CMS options
+### 💚 Netlify and Netlify CMS
+ 
+You don't have to use Netlify, but this is the best option if you need **Netlify CMS** which works best with Netlify. **It takes just a few clicks** to make it work, more info is in the documentation.
 
-The most popular options, apart from Netlify's offers, are:
+You can simply click this button to get started:
 
-* **Hosting:**
-    * GitHub Pages
-    * GitLab Pages
-    * Cloudflare Pages
-    * Vercel
-* **Admin panels / CMS:**
-    * Forestry.io
-    * Or just use your Git provider (github.com, gitlab.com, etc)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cstate/example)
 
-You can also look at [other headless CMS options **(we use Git-based CMS types)** on jamstack.org](https://jamstack.org/headless-cms/).
-
-### GitLab Pages
+### 💜 GitLab Pages
 
 Here is a [good guide for getting started with the service.](https://docs.gitlab.com/ee/user/project/pages/#getting-started)
 
-**In short: a `.gitlab-ci.yml` file** is responsible for making cState work. As of v4.2.1, the [cState automatically ships with this file](https://github.com/cstate/cstate/releases/tag/v4.2.1), but support is still experimental.
+**In short: a `.gitlab-ci.yml` file** is responsible for making cState work. As of v4.2.1, the [cState automatically ships with this file](https://github.com/cstate/cstate/releases/tag/v4.2.1), but support is still experimental. It may take up to 30 minutes before the site is available after the first deployment.
 
 As of this time, this is a relatively untested option, but Hugo does seem to generate the right things (this can be checked by downloading the **CI/CD artifacts**).
 
-According to GitLab, it may take up to 30 minutes before the site is available after the first deployment.
-
 You can [make Netlify CMS work on GitLab](https://www.netlifycms.org/docs/gitlab-backend/), but that requires overriding an existing file in the theme. Create a file in `static/admin/config.yml` and follow the instructions linked earlier. (cState by default ships with Git Gateway for Netlify.)
-
-### GitHub Pages, Cloudflare Pages, Vercel, Forestry, and others
-
-There is no official, separate documentation for these, but if you look below to see how to deploy manually, the instructions will be the same everywhere.
-
-### Doing it on your PC
-
-Keep reading to see how to deploy manually. Developers wishing to contribute, scroll to the very bottom.
 
 ### Manual builds
 
@@ -159,15 +149,13 @@ For this tutorial, it is assumed that you have Hugo and Git installed (check wit
 git clone --recursive -b master https://github.com/cstate/example.git
 ```
 
-(We are using `--recursive` because the site will not generate with an empty `themes/cstate` folder.)
-
-Now you can edit what's inside the folder (`example`) and try previewing that with this command:
+Now you can edit what's inside the folder (`cd example`) and try previewing that with this command:
 
 ```bash
 hugo serve
 ```
 
-Once the changes you wanted done are finished, generate the final files like this:
+Edit the config file. Once the changes you wanted done are finished, generate the final files like this:
 
 ```
 hugo
@@ -175,11 +163,11 @@ hugo
 
 And the folder `public` can now be hosted.
 
-The downside with manual building is that, if you do not want to use a solution like GitLab Pages or Netlify, this process will need to happen on your computer. This can be tedious.
+As you can imagine, manual building is a little bit tedious but a great option to have available programatically.
 
 ### Docker
 
-cState comes with a Dockerfile and Netlify ([according to their article from 2016](https://www.netlify.com/blog/2016/10/18/how-our-build-bots-build-sites/)) uses a similar Docker system to build cState. This is an option for people who prefer Docker and NGINX instead of serverless, but serverless still has the priority in our development. 
+cState comes with a Dockerfile and Netlify ([according to their article from 2016](https://www.netlify.com/blog/2016/10/18/how-our-build-bots-build-sites/)) uses a similar Docker system to build cState. This is an option for people who prefer Docker and NGINX instead of serverless, but serverless still has the priority in cState development. 
 
 [Read wiki](https://github.com/cstate/cstate/wiki/Docker)
 
@@ -311,7 +299,7 @@ hugo serve --config=exampleSite/config.yml --theme=../ --contentDir=exampleSite/
 
 [MIT](https://github.com/cstate/cstate/blob/master/LICENSE.md) © [Mantas Vilčinskas](https://vilcinskas.me)
 
-A special thanks to all [the contributors](https://github.com/cstate/cstate/graphs/contributors)
+A special thanks to all [the contributors](https://github.com/cstate/cstate/graphs/contributors)!
 
 **Note about versions**
 

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -17,6 +17,6 @@
     command = "hugo -b $DEPLOY_PRIME_URL"
 
 [[headers]]
-    for = ["/*.json", "/*.xml"]
+    for = ["/*"]
     [headers.values]
       Access-Control-Allow-Origin = "*"

--- a/exampleSite/static/_headers
+++ b/exampleSite/static/_headers
@@ -1,0 +1,2 @@
+/*
+  Access-Control-Allow-Origin: *

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,6 +1,6 @@
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}{{ $active := where $incidents "Params.resolved" "=" false }}{{ $isNotice := where $active "Params.severity" "=" "notice" }}{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}{{ $isDown := where $active "Params.severity" "=" "down" }}{
   "is": "index",
-  "cStateVersion": "5.4",
+  "cStateVersion": "5.5",
   "apiVersion": "2.0",
   "title": "{{ .Site.Title }}",
   "languageCodeHTML": "{{ .Site.LanguageCode }}",

--- a/layouts/partials/index/announcements.html
+++ b/layouts/partials/index/announcements.html
@@ -1,11 +1,13 @@
-{{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
-{{ $active := where $incidents "Params.resolved" "=" false }}
-{{ $activeIncidents := where $incidents "Params.informational" "=" false }}
-{{ $pinned := where $incidents "Params.pin" "=" true }}
+{{ $allPosts := where .Site.RegularPages "Params.section" "issue" }}
+{{ $active := where $allPosts "Params.resolved" "=" false }}
 
-{{ if or ($activeIncidents) ($pinned) }}
+{{ $informationals := where $allPosts "Params.informational" "=" true }}
+{{ $pinned := where $informationals "Params.pin" "=" true }}
+
+
+{{ if or ($active) ($pinned) }}
   <div class="announcement-box" style="border-bottom: 0">
-    {{ range $activeIncidents }}
+    {{ range $active }}
       <div class="padding">
         <p>
           <a href="{{ .RelPermalink }}"><strong class="bold">{{ .Title }} →</strong></a>
@@ -19,7 +21,7 @@
           {{ end }}
         </small></p>
 
-        {{ .Content | safeHTML | truncate 500 "…" }} <a href="{{ .RelPermalink }}"><b>→</b></a>
+        {{ .Content | safeHTML | truncate 500 "…" }}
         <p></p>
       </div>
       <hr class="clean announcement-box">

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -43,19 +43,19 @@
       {{ $categorySystems := where $systems "category" "=" .name }}
 
       <div class="components">
-      {{ range $categorySystems }}
-        {{ $activeComponentIssues := where $active "Params.affected" "intersect" (slice .name) }}
+      {{ range $system := $categorySystems }}
+        {{ $activeComponentIssues := where $active "Params.affected" "intersect" (slice $system.name) }}
 
         {{ $thisIsNotice := where $activeComponentIssues "Params.severity" "=" "notice" }}
         {{ $thisIsDisrupted := where $activeComponentIssues "Params.severity" "=" "disrupted" }}
         {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
         <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
-          <a href="{{ printf "/affected/%s/" (.name | urlize) | relURL }}" class="no-underline">
-            {{ default .name .displayName }}
+          <a href="{{ printf "/affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
+            {{ default $system.name $system.displayName }}
           </a>
 
-          {{ with .description }}
+          {{ with $system.description }}
             <span class="tooltip tooltip--small">
               &nbsp; <span class="faded">(?)</span>
 
@@ -65,7 +65,7 @@
             </span>
           {{ end }}
 
-          {{ with .link }}
+          {{ with $system.link }}
             <span class="span-icon">
               <a href="{{ . }}" class="link-style">
                 🔗
@@ -87,9 +87,9 @@
             {{ end }}{{ end }}{{ end }}
           </span>
 
-          {{ with .partial }}
+          {{ with $system.partial }}
           <div>
-            {{ partial . . }}
+            {{ partial . (dict "system" $system "incidents" $incidents) }}
           </div>
           {{ end }}
         </div>

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -3,7 +3,7 @@
    * Dev toolset
    */
 
-  console.log('cState v5.4 - https://github.com/cstate/cstate');
+  console.log('cState v5.5 - https://github.com/cstate/cstate');
   document.getElementsByTagName('html')[0].className = 'js';
 
   /**

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -12,7 +12,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
-    <meta name="generator" content="cState v5.4 - https://github.com/cstate/cstate">
+    <meta name="generator" content="cState v5.5 - https://github.com/cstate/cstate">
     <meta name="theme-color" content="{{ .Site.Params.brand }}">
     <script>
     var themeBrandColor = '{{ .Site.Params.brand }}';


### PR DESCRIPTION
cstate turns 5 years old this year! happy hacktoberfest!

- #243 – replace icons to be better supported across operating systems
- #246 - translation bugfix  (disrupted label did not show)
- #248 - Respect timezone even in last modified date when timeZone was set
- Better out of the box support for Cloudflare Pages:

To allow for the reading of API output by default on CF Pages, a `_headers` file is now added to /static/ from this version on. Netlify still has `netlify.toml` from the root. https://developers.cloudflare.com/pages/platform/headers/

this update is mostly supposed to coincide with html-embed 