### PR TITLE
Respect timezone even in last modified date when `timeZone` was set

### DIFF
--- a/layouts/issues/single.html
+++ b/layouts/issues/single.html
@@ -21,7 +21,7 @@
       <p>{{ T "lastChecked" }}:
 
         {{ if .Site.Params.dateFormat }}
-        {{ .Lastmod.UTC.Format .Site.Params.dateFormat }}
+        {{ .Lastmod.Format .Site.Params.dateFormat }}
       {{ else }}
         {{ .Lastmod.Format "January 2, 2006 at 3:04 PM" }}
       {{ end }}

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -131,7 +131,7 @@
 
         if (highlestLevelStatus === 'ok') { highlestLevelStatusReadable = '{{ T "thisIsOk" }}' } 
         if (highlestLevelStatus === 'notice') { highlestLevelStatusReadable = '{{ T "thisIsNotice" }}' } 
-        if (highlestLevelStatus === 'dsirupted') { highlestLevelStatusReadable = '{{ T "thisIsDisrupted" }}' } 
+        if (highlestLevelStatus === 'disrupted') { highlestLevelStatusReadable = '{{ T "thisIsDisrupted" }}' } 
         if (highlestLevelStatus === 'down') { highlestLevelStatusReadable = '{{ T "thisIsDown" }}' } 
 
         // Finally we can show the status 


### PR DESCRIPTION
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

This PR stops forcefully converting the last modified date into UTC to respect Hugo's `timeZone` configuration.

As described in https://github.com/cstate/cstate/pull/249#issue-1426673086, I understand this will be a breaking change.  If we should keep backward compatibility, I will open another PR to introduce `params.forceUTCInLastMod` (key name is subject to discuss).

**Test plan**

No particular test plan because the change is small. I checked in my local as below:

- `config.yaml`:
   ```yaml
   timeZone: Asia/Tokyo
   params:
     dateFormat: January 2, 2006 at 3:04 PM MST
     shortDateFormat: 15:04 MST — Jan 2
     enableLastMod: true
   ```
- last modified info in git:
   ```console
   ❯ git --no-pager log -1 content/issues/2022-10-27-sample-issue.md
   commit 4b...masked....14
   Author: ...masked....
   Date:   Thu Oct 27 20:07:33 2022 +0900
   ```

Then, rendered fotter was:

![image](https://user-images.githubusercontent.com/608782/198505462-919065bc-c6f2-4f39-9ce0-f9eff55c8e3f.png)


<!-- Run some tests to make sure the code doesn't throw any errors, is valid, and works on IE8+. -->
<!-- Also, maake sure that the code formatting is in line with the rest of the project. -->

**Closing issues**

closes https://github.com/cstate/cstate/issues/248