### PR TITLE
Fix affected links in subdir to work with Hugo v0.101+

### DIFF
--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -20,7 +20,7 @@
 
   <p><small>
     {{ range .Params.Affected }}
-      <a href="{{ printf "/affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+      <a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
     {{ end }}
   </small></p>
 

--- a/layouts/partials/index/announcements.html
+++ b/layouts/partials/index/announcements.html
@@ -16,7 +16,7 @@
         <p><small>
           {{ range .Params.Affected }}
               
-          <a href="{{ printf "/affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+          <a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
           
           {{ end }}
         </small></p>
@@ -37,7 +37,7 @@
         <p><small>
           {{ range .Params.Affected }}
               
-          <a href="{{ printf "/affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+          <a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
           
           {{ end }}
         </small></p>

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -51,7 +51,7 @@
         {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
         <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
-          <a href="{{ printf "/affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
+          <a href="{{ printf "affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
             {{ default $system.name $system.displayName }}
           </a>
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

When run with `cd exampleSite && hugo serve --baseUrl=http://localhost/cstate/ --theme=cstate --themesDir=../.. --verbose` on Hugo v0.101.0 and above, the services on the main page at `[localhost]/cstate/` and individual issues should now correctly link to `[localhost]/cstate/affected/[service]` instead of `[localhost]/affected/[service]`.
No visible changes on older versions or without a subdirectory.

Fixes #251
