### PR TITLE
Fix hugo fails to run for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /cstate
 RUN apk add --no-cache hugo git
 
 # Download the example site
-RUN git clone -b master --depth=1 https://github.com/cstate/example /cstate
+COPY exampleSite /cstate
 
 # Copy files from this repo into themes/cstate
 RUN mkdir -p /cstate/themes/cstate

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -109,7 +109,7 @@ baseURL: https://example.com
 #
 # We recommend to keep this at `true`.
 # BOOLEAN; `true`, `false`
-enableGitInfo: true
+enableGitInfo: false
 
 
 ############################################################


### PR DESCRIPTION
1. Dockerfile now uses `exampleSite/` in this repo as the example site, instead of a remote git repo. (So fixing #260 does not depends on fixing a remote git repo).
2. Disable enableGitInfo in example site so hugo doesn't complain.

