### PR TITLE
Update announcements.html

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -164,13 +164,16 @@ params:
       category: North Coast
     - name: Website
       description: The web frontend for the application.
+      tooltip: The web frontend for the application.
       category: Uncategorized
       link: https://example.com/
     - name: API
       description: The guts of the application.
+      tooltip: The API
       category: Uncategorized
     - name: Media Proxy
       description: This is the service responsible for serving images, audio, and video. It is reliant on our CDN.
+      tooltip: 
       category: Uncategorized
 
   # What date format to use?

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
         {{ range .Site.Params.systems }}
           {{ if eq .name $title }}
             {{ with .description }}
-              <p class="bold">{{ . }}</p>
+              <p class="bold">{{ . | safeHTML }}</p>
             {{ end }}
           {{ end }}
         {{ end }}

--- a/layouts/partials/index/announcements.html
+++ b/layouts/partials/index/announcements.html
@@ -1,5 +1,6 @@
 {{ $allPosts := where .Site.RegularPages "Params.section" "issue" }}
 {{ $active := where $allPosts "Params.resolved" "=" false }}
+{{ $active := where $active "Params.pin" "!=" false }}
 
 {{ $informationals := where $allPosts "Params.informational" "=" true }}
 {{ $pinned := where $informationals "Params.pin" "=" true }}

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -55,12 +55,12 @@
             {{ default $system.name $system.displayName }}
           </a>
 
-          {{ with $system.description }}
+          {{ with $system.tooltip }}
             <span class="tooltip tooltip--small">
               &nbsp; <span class="faded">(?)</span>
 
               <span class="tooltip__text">
-                {{ . }}
+                {{ . | safeHTML }}
               </span>
             </span>
           {{ end }}


### PR DESCRIPTION
Added filter to exclude incidents from being pinned in the announcements, if they explicitly set the Param "pin: false"
now the "pin: false" works for both: incidents and informationals

suggestion for issue #267 

**Test plan**
it's basically a copy of the filter line below. worked in demo setup

**Closing issues**
closes #267
