### PR TITLE
Severity aware resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can support the creator of this project by starring, sharing, using cState a
 
 ## Sponsors
 
-cState's development is being sposnored by [Instatus](https://instatus.com/) from June, 2022.
+[You can sponsor cState by sponsoring the main developer of the project, @mistermantas](https://github.com/sponsors/mistermantas).
 
 ## Examples 🥳
 

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -47,7 +47,10 @@
           {{ $minutesForCalc := (mod $diffInMin 60) }}
 
           {{ div (sub $diffInMin $minutesForCalc) 60 }}h
-          {{ $minutesForCalc }}m {{ T "ofDowntime" }}.
+          {{ $minutesForCalc }}m
+          {{ if eq .Params.severity "down" }}
+              {{ T "ofDowntime" }}
+          {{ end }}
         </strong>
 
         <span class="tooltip__text">
@@ -66,7 +69,9 @@
           {{ $secsForCalc := (mod $timeDiff 60) }}
 
           {{ div (sub $timeDiff $secsForCalc) 60 }}m
-          {{ T "ofDowntime" }}.
+          {{ if eq .Params.severity "down" }}
+            {{ T "ofDowntime" }}
+          {{ end }}
         </strong>
 
         <span class="tooltip__text">

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -52,7 +52,10 @@
           {{ $minutesForCalc := (mod $diffInMin 60) }}
 
           {{ div (sub $diffInMin $minutesForCalc) 60 }}h
-          {{ $minutesForCalc }}m {{ T "ofDowntime" }}
+          {{ $minutesForCalc }}m
+          {{ if eq .Params.severity "down" }}
+            {{ T "ofDowntime" }}
+          {{ end }}
         </div>
       {{ else }}
         <div class="ok">
@@ -61,7 +64,9 @@
           {{ $secsForCalc := (mod $timeDiff 60) }}
 
           {{ div (sub $timeDiff $secsForCalc) 60 }}m
+          {{ if eq .Params.severity "down" }}
           <!-- {{ $secsForCalc }}s --> {{ T "ofDowntime" }}
+          {{ end }}
         </div>
       {{ end }}
     {{ end }}


### PR DESCRIPTION
**Summary**
Issues history (including individual issues view) currently always shows `Resolved after <x time> of Downtime` even if the issue severity is marked as `disrupted`.

This change seeks to remove the `of Downtime` or language equivalent if the issue severity is anything other than `down`. The approach is to avoid grammar and i18n changes while also acknowledging the issue's severity.

**Change**
Minimal change to only apply the `ofDowntime` mapped text if the issue severity is `down`

**Test plan**
*Pre-Reqs*
* Have an issues matching to following criteria
  * severity is `down` and resolved after time diff is over 1 minute
  * severity is `disrupted` and resolved after time diff is over 1 minute
  * severity is `down` and resolved after time diff is over 1 hour
  * severity is `disrupted` and resolved after time diff is over 1 hour
* Ensure `disableIncidentHistory: false`

*Test Cases*
After serving up the page check the following scenarios
- [x] Assert issues with `disrupted` severity do no show `ofDowntime` mapped text (`of Downtime`)..
  - [x] in issues history (short) view
  - [x] in individual issue view
- [x] Assert issues with `down` severity show `ofDowntime` mapped text (`of Downtime`)..
  - [x] in issues history (short) view
  - [x] in individual issue view

*Screen Shots*
![image](https://github.com/cstate/cstate/assets/19895285/37cfbb0c-abf6-4a6f-9a3f-d1fd0ed6f627)

![image](https://github.com/cstate/cstate/assets/19895285/3461ede5-d148-45f3-bed8-404eaeda7c83)

![image](https://github.com/cstate/cstate/assets/19895285/c6d184cf-1420-4e0e-b42c-1d15783b39cb)

![image](https://github.com/cstate/cstate/assets/19895285/f2ca6a2a-2caf-423a-a969-8f2829501ffb)

**Closing issues**
Closes #264 
