### PR TITLE
Expose pinned issue(s) in index.json

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -17,6 +17,20 @@
       }
     {{ end }}
   ],
+  {{ $informationals := where $incidents "Params.informational" "=" true }}{{ $pinnedIssues := where $informationals "Params.pin" "=" true }}
+  {{ if not $pinnedIssues }}
+  "pinnedIssues": []{{ else }}
+  "pinnedIssues": [{{ range $i, $e := $pinnedIssues }}{{ if $i }},{{ end }}
+      {
+        "is": "issue",
+        "title": "{{ .Title }}",
+        "createdAt": "{{ .Date }}",
+        "lastMod": "{{ .Lastmod }}",
+        "permalink": "{{ .Permalink }}",
+        "affected": [{{ range $i, $e := .Params.Affected }}{{ if $i }}, {{ end }}"{{ . }}"{{ end }}],
+        "filename": "{{ .File.LogicalName }}"
+      }{{ end }}
+  ]{{ end }},
   "systems": [
     {{ range $i, $e := .Site.Params.systems }}{{ if $i }},{{ end }}
       {


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR adds a `pinnedIssues` key to the `index.json` object, which contains issues with `informational` and `pin` set to `true`. The issue objects are very similar to the ones in `unresolvedIssues` for systems, but I've omitted some values that I deemed unnecessary for this specific use (e.g. `.informational` would have always been `true`) -- please let me know if this is fine or if I should re-add some of them.

> Explain the **details** for making this change. What existing problem does the pull request solve?

I would like to access the pinned issues for a particular status page from other services programatically, but there's no way to do that except for scraping the generated HTML pages. This pull request solves that by exposing these issues in the index.json JSON object.

> **Test plan**
- Have an issue with `informational` and `pin` flags set to `true` in the YAML frontmatter
- `index.json` should contain this issue in `pinnedIssues`
- Have a system `A`, after setting the issue frontmatter variables `resolved` to `false` and `affected` to include `A`, the issue should also appear in the `.systems[.name = "A"].unresolvedIssues` array
- Delete the issue (or remove, or set to false one of `informational`, `pin` in the frontmatter); `index.json` should now contain an empty array for `pinnedIssues`

> **Closing issues**

Closes #295