### PR TITLE
Use overflow-wrap on headings

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -68,6 +68,7 @@
       color: #000;
       font-family: "Inter", "Inter UI", "Segoe UI", BlinkMacSystemFont, -apple-system, "San Francisco Display", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       letter-spacing: -0.4px;
+      overflow-wrap: break-word;
     }
 
     h3 {


### PR DESCRIPTION
**Test plan**

With this fix:

<img src="https://github.com/cstate/cstate/assets/44368997/b47e6cda-cfaa-40c5-8d8d-b0a3cafc7d8e" alt="Site screenshot after this change" width="300"><br>

Untested on IE8+, but it should work based on the [compatibility table for overflow-wrap](https://caniuse.com/mdn-css_properties_overflow-wrap_break-word).

**Closing issues**

Closes #285
