### PR TITLE
v6 Overhaul

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Explain the **details** for making this change. What existing problem does the p
 
 Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
 
-<!-- Run some tests to make sure the code doesn't throw any errors, is valid, and works on IE8+. -->
+<!-- Run some tests to make sure the code doesn't throw any errors, is valid, and works on IE11 and up.. -->
 <!-- Also, make sure that the code formatting is in line with the rest of the project. -->
 
 **Closing issues**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 exampleSite/public/
 public/
 exampleSite/themes/
+.hugo_build.lock
+exampleSite/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
- 
+
 
 <p align="center"><img src="images/cstate-logo-bg.svg?sanitize=true" width="500" height="auto" alt="cState example illustration"></p>
 
 
-> Über fast to load and build, backwards compatible (IE8+), tiny, and simple OSS status page built with Hugo. Completely _free_ with Netlify. Comes with Netlify CMS, read-only API, badges like from shields.io, and other useful features.
+> Über fast to load and build, works with legacy browsers such as Internet Explorer, tiny, and simple OSS status page built with Hugo. Completely _free_ with Netlify. Comes with Netlify CMS, read-only API, badges like from shields.io, and other useful features.
 
 
 <p>
@@ -89,7 +89,7 @@ There are other commercial options that may update faster because of their archi
 This is how you create a **new site powered by cState.**  What you are generating is a Hugo site with specific, already existing modifications (to Hugo, cState acts like a theme).
 
 **IF YOU ARE A DEVELOPER / WANT TO CONTRIBUTE TO THE DEVELOPMENT, SCROLL TO THE BOTTOM. THIS IS FOR USERS.**
- 
+
 Aside from hosting the repository itself on Git (usually on GitHub), your next options are:
 
 * **Site deployment platform:**
@@ -122,10 +122,10 @@ All other static site generator platforms require you to follow this instruction
 + Publish directory: **public**
 + Add one build environment variable
   + Key: **HUGO_VERSION**
-  + Value: **0.101.0** (or later) 
+  + Value: **0.101.0** (or later)
 
 ### 💚 Netlify and Netlify CMS
- 
+
 You don't have to use Netlify, but this is the best option if you need **Netlify CMS** which works best with Netlify. **It takes just a few clicks** to make it work, more info is in the documentation.
 
 You can simply click this button to get started:
@@ -176,7 +176,7 @@ As you can imagine, manual building is a little bit tedious but a great option t
 
 ### Docker
 
-cState comes with a Dockerfile and Netlify ([according to their article from 2016](https://www.netlify.com/blog/2016/10/18/how-our-build-bots-build-sites/)) uses a similar Docker system to build cState. This is an option for people who prefer Docker and NGINX instead of serverless, but serverless still has the priority in cState development. 
+cState comes with a Dockerfile and Netlify ([according to their article from 2016](https://www.netlify.com/blog/2016/10/18/how-our-build-bots-build-sites/)) uses a similar Docker system to build cState. This is an option for people who prefer Docker and NGINX instead of serverless, but serverless still has the priority in cState development.
 
 [Read wiki](https://github.com/cstate/cstate/wiki/Docker)
 
@@ -235,13 +235,13 @@ This is what you would see for an issue that has been resolved.
 
 Time to break that down.
 
-`title`: This is the one of the most important parts of an incident. *(required)*  
-`date`: An ISO-8601 formatted date. Does not include time zone. This is when you first discovered the issue. *(required)*  
-`resolved`: Whether issue should affect overall status. Either `true` or `false`. *(boolean, required)*  
-`resolvedWhen`: An ISO-8601 formatted date. Does not include time zone. This is when downtime stopped. You may set the time that downtime ended without completely resolving the issue (thus leaving time for monitoring).  
-`severity`: If an issue is not resolved, it will have an applied severity. There are 3 levels of severity: `notice`, `disrupted`, and `down`. If there are multiple issues, the status page will take the appearance of the more drastic issue (such as `disrupted` instead of `notice`). *(required)*  
-`affected`. Add the items that were present in the config file which should alter the status of each individual system (component). *(array, required)*  
-`section`. This must be `issue`, so that Hugo treats it as one. *(required)*  
+`title`: This is the one of the most important parts of an incident. *(required)*
+`date`: An ISO-8601 formatted date. Does not include time zone. This is when you first discovered the issue. *(required)*
+`resolved`: Whether issue should affect overall status. Either `true` or `false`. *(boolean, required)*
+`resolvedWhen`: An ISO-8601 formatted date. Does not include time zone. This is when downtime stopped. You may set the time that downtime ended without completely resolving the issue (thus leaving time for monitoring).
+`severity`: If an issue is not resolved, it will have an applied severity. There are 3 levels of severity: `notice`, `disrupted`, and `down`. If there are multiple issues, the status page will take the appearance of the more drastic issue (such as `disrupted` instead of `notice`). *(required)*
+`affected`. Add the items that were present in the config file which should alter the status of each individual system (component). *(array, required)*
+`section`. This must be `issue`, so that Hugo treats it as one. *(required)*
 
 You don't have to define a date for `resolvedWhen` when the issue is not resolved (obviously):
 
@@ -289,10 +289,10 @@ git clone --recursive -b master https://github.com/cstate/cstate.git
 # old command
 # navigate to the directory where your content is and start dev server from there
 cd cstate/exampleSite
-hugo serve --baseUrl=http://localhost/ --theme=cstate --themesDir=../.. --verbose
+hugo server --theme=cstate --themesDir=../..
 # new command partially works for v5.0.2; does not load images from static/
 # for this you need to be in the theme root
-hugo serve --config=exampleSite/config.yml --theme=../ --contentDir=exampleSite/content
+hugo server --config=exampleSite/config.yml --theme=../ --contentDir=exampleSite/content
 ```
 
 

--- a/exampleSite/README.md
+++ b/exampleSite/README.md
@@ -1,4 +1,4 @@
-# cState Site v5.0
+# cState Site v6.0
 
 This is the default cState status page website directory/folder.
 

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -183,8 +183,8 @@ params:
   #
   # dateFormat Default: "January 2, 2006 at 3:04 PM"
   # shortDateFormat Default: "15:04 — Jan 2"
-  dateFormat: January 2, 2006 at 3:04 PM UTC
-  shortDateFormat: 15:04 UTC — Jan 2
+  dateFormat: January 2, 2006 at 3:04 PM
+  shortDateFormat: 15:04 — Jan 2
   # Note: "at" is not translated with language codes, e.g.
   # for German, it would be "um", so change it if needed.
 

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -89,7 +89,7 @@ defaultContentLanguage: en
 # version 3. If you are just testing,
 # localhost should automatically work.
 #
-# Example: 
+# Example:
 # baseUrl: https://status.example.com/
 #
 # For testing:
@@ -139,7 +139,7 @@ params:
   #   Or it can be used alongside other categories.
   #
   # These are case sensitive.
-  # 
+  #
   # For help, see the wiki:
   # https://github.com/cstate/cstate/wiki/Customization
   categories:
@@ -188,7 +188,7 @@ params:
   # Should relative time (x min ago) be used?
   #
   # IMPORTANT: In the frontmatter, the dates MUST be in
-  # the UTC time zone for this to work properly. If you 
+  # the UTC time zone for this to work properly. If you
   # use Netlify CMS, all good — the CMS picks UTC time
   # by default. Otherwise, there may be very inaccurate
   # times if multiple time zones are in your issue files.
@@ -198,8 +198,8 @@ params:
   # wish to use relative time but old issues do not have
   # UTC time (and therefore are out of sync by ±24 hours)
   #
-  # Read the wiki for more: 
-  # https://github.com/cstate/cstate/wiki/Customization#time 
+  # Read the wiki for more:
+  # https://github.com/cstate/cstate/wiki/Customization#time
   #
   # If enabled, will display relative times in places like
   # the incident history and summaries instead of using
@@ -209,7 +209,7 @@ params:
   # Default: `true`
   # BOOLEAN; `true`, `false`
   useRelativeTime: true
- 
+
   # If enabled, doesn't show seconds on relative times.
   #
   # With option ON (true):
@@ -378,6 +378,7 @@ params:
   #
   # Default: UA-00000000-1
   googleAnalytics: UA-00000000-1
+
 
 # These options affect the core of cState.
 # Please do not change them if you do not

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -166,7 +166,7 @@ params:
     - name: Website
       description: The web frontend for the application.
       category: Uncategorized
-      histogram: false # explicitely disable histogram for this system
+      histogram: false # explicitly disable histogram for this system
       link: https://example.com/
     - name: API
       description: The guts of the application.
@@ -175,7 +175,7 @@ params:
       description: This is the *service* responsible for serving images, audio, and video. It is reliant on our CDN.
       category: Uncategorized
 
-  # Want to disable the uptime histogram?
+  # Want to enable the uptime histogram?
   # Set this to `false` for any system you want to disable.
   #
   # Default: `true`
@@ -184,8 +184,6 @@ params:
 
   # TODO:
   # Monitor bots
-  #
-  #
   #
   # If you have a monitor bot, you get access to
   # more features like notifications to Slack,
@@ -360,9 +358,9 @@ params:
   # To disable this feature, comment
   # out the line below.
   #
-  # Default: `6`
-  # NUMERIC; Default: `6`
-  incidentMaxAgeYears: 6
+  # Default: empty
+  # NUMERIC
+  # incidentMaxAgeYears: 10
 
   # Colors throughout cState
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -236,12 +236,12 @@ params:
   useLargeHeaderDesign: false
 
   # Should incident history be separated
-  # like in an archive view?
+  # in the archive view by year or month?
   #
-  # Note: This WILL disable pagination.
+  # Only takes affect on /issues/ page.
   #
   # Default: `yearly`
-  # STRING; `monthly`, `yearly`, `none`
+  # STRING; `monthly`, `yearly`
   incidentHistoryFormat: "yearly"
 
   # Should incident history be hidden?
@@ -315,11 +315,30 @@ params:
   # BOOLEAN; `true`, `false`
   disableComplexCalculations: false
 
-  # Incident posts shown
-  # in one page
+  # Incident posts shown on homepage
   #
-  # NUMERIC; Default: `10`
-  incidentPostsPerPage: 10
+  # NUMERIC; Default: `5`
+  incidentPostsPerPage: 5
+
+  # Introduced in v6, you can hide
+  # incidents that are older than
+  # this number of years.
+  #
+  # Note: this does not mean they
+  # are no longer accessible.
+  # If you still have the issue
+  # link, you can still access it.
+  #
+  # We recommend to keep this at `6`.
+  # This will hide incidents older
+  # than 6 years on /issues/ archive.
+  #
+  # To disable this feature, comment
+  # out the line below.
+  #
+  # Default: `6`
+  # NUMERIC; Default: `6`
+  incidentMaxAgeYears: 6
 
   # Colors throughout cState
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -119,10 +119,6 @@ enableGitInfo: false
 ############################################################
 
 params:
-  uptimeHistogramEnabled: true
-  uptimeHistogramDays: 30
-  uptimeHistogramWidth: 1000
-
   # Before setting up your systems, you need
   # to first define at least one category.
   #
@@ -170,6 +166,7 @@ params:
     - name: Website
       description: The web frontend for the application.
       category: Uncategorized
+      histogram: false # explicitely disable histogram for this system
       link: https://example.com/
     - name: API
       description: The guts of the application.
@@ -177,6 +174,26 @@ params:
     - name: Media Proxy
       description: This is the *service* responsible for serving images, audio, and video. It is reliant on our CDN.
       category: Uncategorized
+
+  # Want to disable the uptime histogram?
+  # Set this to `false` for any system you want to disable.
+  #
+  # Default: `true`
+  # BOOLEAN; `true`, `false`
+  enableUptimeHistogram: true
+
+  # TODO:
+  # Monitor bots
+  #
+  #
+  #
+  # If you have a monitor bot, you get access to
+  # more features like notifications to Slack,
+  # Discord, and more.
+  #
+  # Default: `false`
+  # STRING or BOOLEAN to disable
+  monitorBot: false
 
   # What date format to use?
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -78,7 +78,7 @@ languageCode: en
 # than English! When tested with Lithuanian,
 # it would add unnecessary placeholders to
 # values that were intentionally empty.
-defaultContentLanguage: en
+defaultContentLanguage: lt
 
 # What is the hostname or path to the root?
 # Where is the site hosted?
@@ -182,12 +182,14 @@ params:
   # BOOLEAN; `true`, `false`
   enableUptimeHistogram: true
 
-  # TODO:
-  # Monitor bots
+  # Monitor bot
   #
   # If you have a monitor bot, you get access to
   # more features like notifications to Slack,
   # Discord, and more.
+  #
+  # The monitor bot is compatible v6 and up.
+  # It is released here: https://github.com/cstate/monitorbot
   #
   # Default: `false`
   # STRING or BOOLEAN to disable
@@ -341,6 +343,15 @@ params:
   #
   # NUMERIC; Default: `5`
   incidentPostsPerPage: 5
+
+  # Enable custom CSS, JS, HTML
+  #
+  # Edit the files in /layouts/partials/custom/
+  # to customize your status page.
+  #
+  # Default: `true`
+  # BOOLEAN; `true`, `false`
+  enableCustomHTML: true
 
   # Introduced in v6, you can hide
   # incidents that are older than

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -119,6 +119,10 @@ enableGitInfo: false
 ############################################################
 
 params:
+  uptimeHistogramEnabled: true
+  uptimeHistogramDays: 30
+  uptimeHistogramWidth: 1000
+
   # Before setting up your systems, you need
   # to first define at least one category.
   #
@@ -148,7 +152,7 @@ params:
       closed: true
       untitled: false
     - name: Uncategorized
-      untitled: false
+      untitled: true
 
   # These are your systems. Change them to
   # change the amount of components.

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -184,6 +184,8 @@ params:
   # shortDateFormat Default: "15:04 — Jan 2"
   dateFormat: January 2, 2006 at 3:04 PM UTC
   shortDateFormat: 15:04 UTC — Jan 2
+  # Note: "at" is not translated with language codes, e.g.
+  # for German, it would be "um", so change it if needed.
 
   # Should relative time (x min ago) be used?
   #

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -161,6 +161,7 @@ params:
     - name: Gateway
       category: North Coast
     - name: Backup Gateway
+      description: This is a description for a system with no recorded downtime.
       category: North Coast
     - name: Website
       description: The web frontend for the application.
@@ -170,7 +171,7 @@ params:
       description: The guts of the application.
       category: Uncategorized
     - name: Media Proxy
-      description: This is the service responsible for serving images, audio, and video. It is reliant on our CDN.
+      description: This is the *service* responsible for serving images, audio, and video. It is reliant on our CDN.
       category: Uncategorized
 
   # What date format to use?

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -146,9 +146,9 @@ params:
     - name: North Coast
       description: The main servers are located here.
       closed: true
-    - name: Empty Category
+      untitled: false
     - name: Uncategorized
-      untitled: true
+      untitled: false
 
   # These are your systems. Change them to
   # change the amount of components.

--- a/exampleSite/content/affected/api/_index.md
+++ b/exampleSite/content/affected/api/_index.md
@@ -1,0 +1,12 @@
+---
+title: API # make sure to match the name of the system in the config file
+---
+
+On top of defining a description for each system, you can also create a page for each system. This is useful if you want to add more information about the system, such as a link to the documentation, or a list of affected components.
+
+This page is optional, but if you do not create one, the status page will not show the system in the summary.
+
+**IMPORTANT:** If you create a page for a system, you must also create a corresponding entry in the `systems` list in the config file. Otherwise, the status page will not know which system to display.
+
+For example, if you have a system called `API`, you can create a page called `api.md` in the `affected` folder. The content of the page will be shown in the summary.
+

--- a/exampleSite/content/issues/2018-01-17-sending-dms-impacted.md
+++ b/exampleSite/content/issues/2018-01-17-sending-dms-impacted.md
@@ -1,8 +1,8 @@
 ---
 title: Issues Sending DMs
 date: 2017-12-17 16:24:00
-resolved: true
-resolvedWhen: 2017-12-17 16:58:00
+resolved: false
+resolvedWhen: 2017-12-19 16:58:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:

--- a/exampleSite/content/issues/2018-01-17-sending-dms-impacted.md
+++ b/exampleSite/content/issues/2018-01-17-sending-dms-impacted.md
@@ -1,7 +1,7 @@
 ---
 title: Issues Sending DMs
 date: 2017-12-17 16:24:00
-resolved: false
+resolved: true
 resolvedWhen: 2017-12-19 16:58:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted

--- a/exampleSite/content/issues/2018-04-13-unavailable-guilds-connection-issues.md
+++ b/exampleSite/content/issues/2018-04-13-unavailable-guilds-connection-issues.md
@@ -5,9 +5,7 @@ resolved: true
 resolvedWhen: 2018-04-13 17:30:00
 # Possible severity levels: down, disrupted, notice
 severity: down
-affected:
-  - API
-  - Media Proxy
+affected: [API, Media Proxy]
 section: issue
 ---
 

--- a/exampleSite/content/issues/2018-05-25-us-east-conn-issues.md
+++ b/exampleSite/content/issues/2018-05-25-us-east-conn-issues.md
@@ -8,7 +8,6 @@ severity: down
 affected:
   - API
   - Media Proxy
-  - Gateway
 section: issue
 ---
 

--- a/exampleSite/content/issues/2024-02-24-maintenance-window.md
+++ b/exampleSite/content/issues/2024-02-24-maintenance-window.md
@@ -1,8 +1,11 @@
 ---
-title: Maintenance Announcement 
-date: 2024-02-24 10:35:00 
-informational: true
-pin: true 
+title: Maintenance Announcement
+date: 2024-02-24 10:35:00
+resolvedWhen: 2024-02-24 11:35:00
+affected:
+  - API
+resolved: true
+severity: notice
 section: issue
 ---
 

--- a/exampleSite/content/issues/2024-05-23-planning-meeting.md
+++ b/exampleSite/content/issues/2024-05-23-planning-meeting.md
@@ -1,0 +1,9 @@
+---
+title: cState v6 Planning Meeting
+date: 2024-02-24 10:35:00
+informational: true
+pin: false
+section: issue
+---
+
+It's true, we are not going to be able to fix the issues in the next few days. We will be working on the next version of cState, which will be released in the coming weeks. We will also be working on a new website, which will be released in the coming months.

--- a/exampleSite/content/issues/2024-07-23-excitement.md
+++ b/exampleSite/content/issues/2024-07-23-excitement.md
@@ -1,0 +1,22 @@
+---
+title: Exciting Downtime
+date: 2024-07-23 10:35:00
+resolved: true
+resolvedWhen: 2024-07-23 10:38:00
+severity: down
+affected:
+  - API
+pin: false
+section: issue
+---
+
+Our servers are down for a few minutes. We will be back up shortly. {{< track "2024-02-24 10:35:00" >}}
+
+---
+
+*Investigating* - We are investigating a potential issue that might affect the uptime of one our of services. We are sorry for any inconvenience this may cause you. This incident post will be updated once we have more information.
+{{< track "2024-02-24 10:35:00" >}}
+
+---
+
+*Fixed* - We have fixed the issue. The servers were super excited to be back up and running. {{< track "2024-02-24 10:35:00" >}}

--- a/exampleSite/content/issues/2024-12-24-cstate-showdown.md
+++ b/exampleSite/content/issues/2024-12-24-cstate-showdown.md
@@ -5,7 +5,7 @@ resolvedWhen: 2024-12-24 13:35:00
 affected:
   - API
 resolved: true
-severity: notice
+severity: disrupted
 section: issue
 ---
 

--- a/exampleSite/content/issues/2024-12-24-cstate-showdown.md
+++ b/exampleSite/content/issues/2024-12-24-cstate-showdown.md
@@ -1,0 +1,15 @@
+---
+title: cState v6 Showdown
+date: 2024-12-24 10:35:00
+resolvedWhen: 2024-12-24 13:35:00
+affected:
+  - API
+resolved: true
+severity: notice
+section: issue
+---
+
+cState v6 is coming! It's now in development and will be ready for you in 2025.
+
+Regular support for cState returns, and the old version 5.x will be supported until mid 2025.
+

--- a/exampleSite/content/issues/2024-12-27-dns-resolution-api.md
+++ b/exampleSite/content/issues/2024-12-27-dns-resolution-api.md
@@ -1,0 +1,14 @@
+---
+title: "API DNS resolution error!"
+date: 2024-12-27T09:43:40.482Z
+resolved: false
+severity: "down"
+affected: ["API"]
+automated: true
+id: "dns-resolution-api"
+section: issue
+---
+
+*This issue has been ongoing for a number of consecutive checks and has been escalated to a **severe** status. A human has been alerted and will take action as soon as possible. For support, please contact us on the information present on this website's homepage.* {{< track "2024-12-27T09:44:00.481Z" >}}
+
+**Automated system alert* - We are sensing a disruption in our dns-resolution monitor. This means that end users may experience issues with our "API". This may be temporary.* {{< track "2024-12-27T09:43:40.482Z" >}}

--- a/exampleSite/layouts/partials/custom/meta.html
+++ b/exampleSite/layouts/partials/custom/meta.html
@@ -3,6 +3,8 @@
 This file can be used to add custom HTML
 to your cState powered status page.
 
+There's more files like this one. Check them out at:
+
 https://github.com/cstate/cstate/wiki/Customization
 
 -->
@@ -13,7 +15,8 @@ https://github.com/cstate/cstate/wiki/Customization
 	rel="stylesheet">
 <style>
 	/* Example of custom CSS */
-	html, body {
+	html,
+	body {
 		font-family: 'DM Sans', sans-serif;
 	}
 </style>

--- a/exampleSite/static/admin/config.yml
+++ b/exampleSite/static/admin/config.yml
@@ -9,8 +9,10 @@
 #
 # https://github.com/netlify/netlify-cms/blob/master/docs/quick-start.md
 
+local_backend: true
+
 backend:
-  name: git-gateway
+  name: github
 media_folder: "static/img"
 public_folder: "/img"
 site_url: ../
@@ -62,6 +64,9 @@ collections:
       - label: "Affected systems (use exact name, separated by commas) 🧐"
         name: "affected"
         widget: "list"
+        summary: "{{fields.individualaffected}}"
+        fields:
+        - { label: "Affected System", name: "individualaffected", widget: "string" }}
         required: false
       - label: "Severity ⚠"
         name: "severity"
@@ -151,7 +156,7 @@ collections:
             widget: 'string'
             hint: 'Where is the site hosted? Hostname (and path) to the root. Prior to version 3, a slash was used which now works in local testing, but breaks certain features of cState like RSS feeds, so a correct example for production is: https://cstate.mnts.lt'
             default: '/'
-              
+
           # REQUIRED BUT HIDDEN
           - label: 'theme'
             name: 'theme'
@@ -195,7 +200,7 @@ collections:
             widget: "hidden"
             fields:
               - label: "svg"
-                name: svg 
+                name: svg
                 fields:
                 - label: "isPlainText"
                   name: isPlainText
@@ -209,7 +214,7 @@ collections:
             widget: 'hidden'
             required: false
             default: true
-            
+
           # PARAMS
           - label: "Params"
             name: "params"

--- a/exampleSite/static/admin/config.yml
+++ b/exampleSite/static/admin/config.yml
@@ -65,8 +65,8 @@ collections:
         name: "affected"
         widget: "list"
         summary: "{{fields.individualaffected}}"
-        fields:
-        - { label: "Affected System", name: "individualaffected", widget: "string" }}
+        field:
+        - { label: "Affected System", name: "individualaffected", widget: "string" }
         required: false
       - label: "Severity ⚠"
         name: "severity"
@@ -320,7 +320,7 @@ collections:
                 name: 'incidentPostsPerPage'
                 hint: ''
                 widget: 'number'
-                valueType: 'int'
+                value_type: 'int'
                 min: 1
                 max: 100
                 default: 10

--- a/exampleSite/static/admin/config.yml
+++ b/exampleSite/static/admin/config.yml
@@ -145,6 +145,7 @@ collections:
             - { label: "🇸🇪 Swedish", value: "se" }
             - { label: "🇮🇩 Indonesian", value: "id" }
             - { label: "🇵🇱 Polska", value: "pl" }
+            - { label: "🇷🇴 Română", value: "ro" }
             - { label: "🇷🇺 Русский", value: "ru" }
           - label: 'Site language in code for html[lang]'
             hint: 'Use the ISO 639-1 defined abbreviations. Examples: en, lt, de. Fully explained here: https://github.com/cstate/cstate/wiki/Customization#changing-site-language'

--- a/exampleSite/static/admin/index.html
+++ b/exampleSite/static/admin/index.html
@@ -15,8 +15,8 @@
     -->
 
     <script>console.log('You are using cState. The version can be looked at from the console on the homepage or incidents view. https://github.com/cstate')</script>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+
+	<script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script>
       var IssuePreview = createClass({
         render: function() {
@@ -37,7 +37,7 @@
             var resultOfStateProps = {"class": "green"};
             var resultOfState = '';
           }
-          
+
 
           return h('div', {},
             h('h1', {}, entry.getIn(['data', 'title'])),

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -1,6 +1,5 @@
 # Bangla language file for cState
-
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: bn
@@ -116,7 +115,7 @@
 - id: notFoundText
   translation: এটি আমাদের পক্ষ থেকে একটি সমস্যা হতে পারে। সম্ভবত আমরা একটি নির্দিষ্ট রিসোর্স স্থানান্তরিত করেছি এবং এখন এটি চলে গেছে। এটাও সম্ভব যে আপনি যে রিসোর্সটি দেখার চেষ্টা করছেন সেটি খালি। কিন্তু আপনি কি আবার লিঙ্ক চেক করতে আপত্তি করবেন?
 
-- id: rss
+- id: subscribeViaRss
   translation: RSS এর মাধ্যমে সাবস্ক্রাইব করুন
 - id: toAllUpdates
   translation: সব আপডেট
@@ -160,8 +159,71 @@
 - id: yearAgo
   translation: " year"
 
-
 ## v6
 ##
 - id: incidentMaxAgeNotice
   translation: "{{ .MaxAgeYears }} বছর আগে ঘটে যাওয়া ঘটনাগুলি আর দেখানো হবে না"
+- id: loading
+  translation: "লোড হচ্ছে"
+- id: chart
+  translation: "চার্ট"
+- id: getSupport
+  translation: "সহায়তা পান"
+- id: subscribe
+  translation: "সাবস্ক্রাইব"
+- id: subscribeDescription
+  translation: "এই স্ট্যাটাস পেজ থেকে আপডেটের জন্য সাবস্ক্রাইব করুন।"
+- id: rss
+  translation: "আরএসএস"
+- id: email
+  translation: "ইমেল"
+- id: discord
+  translation: "ডিসকর্ড"
+- id: slack
+  translation: "স্ল্যাক"
+- id: webhook
+  translation: "ওয়েবহুক"
+- id: webhookUrl
+  translation: "ওয়েবহুক URL"
+- id: embed
+  translation: "এম্বেড"
+- id: embedDescription
+  translation: "আপনি আপনার নিজের ওয়েবসাইট বা অ্যাপ্লিকেশনে এই স্ট্যাটাস পৃষ্ঠাটি এম্বেড করতে পারেন। বিঘ্ন ঘটলে একটি পপ-আপ বার্তা পেতে নিম্নলিখিত HTML স্নিপেটটি অনুলিপি করে পেস্ট করুন:"
+- id: copy
+  translation: "কপি"
+- id: embedDisclaimer
+  translation: "এই এম্বেড সম্পর্কে আরও তথ্য এবং আপনি কীভাবে এটি ব্যবহার করতে পারেন তা খুঁজছেন?"
+- id: learnMore
+  translation: "এখানে আরও জানুন"
+- id: pushNotifications
+  translation: "পুশ বিজ্ঞপ্তি"
+- id: pushNotificationsDescription
+  translation: "আপনি আপনার ব্রাউজারের মাধ্যমে পুশ বিজ্ঞপ্তির মাধ্যমে এই স্ট্যাটাস পৃষ্ঠাতে সাবস্ক্রাইব করতে পারেন। আপনি যে ডিভাইসগুলিতে বিজ্ঞপ্তি পেতে চান তার প্রত্যেকটিতে আপনাকে এটি করতে হবে। অনুগ্রহ করে মনে রাখবেন যে এই বৈশিষ্ট্যটি ব্রাউজার সমর্থনের অধীন এবং প্রত্যাশিত হিসাবে সমস্ত ডিভাইসে কাজ নাও করতে পারে।"
+- id: pushNotificationsDisclaimer
+  translation: "আপনার যদি যত তাড়াতাড়ি সম্ভব সমালোচনামূলক আপডেট সরবরাহ করার প্রয়োজন হয় তবে আমরা বিজ্ঞপ্তির একটি ভিন্ন পদ্ধতি বেছে নেওয়ার পরামর্শ দিই।"
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "আপনি আমাদের API ব্যবহার করে এই স্ট্যাটাস পৃষ্ঠা থেকে তথ্য এবং আপডেটগুলিকে আপনার নিজের ওয়েবসাইট বা অ্যাপ্লিকেশনে সংহত করতে পারেন। নিম্নলিখিত URL-এ একটি GET অনুরোধ করুন:"
+- id: APIdisclaimer
+  translation: "অনুগ্রহ করে মনে রাখবেন যে API হার সীমিত হতে পারে।"
+- id: getAllUpdates
+  translation: "সমস্ত আপডেট পান"
+- id: getSomeUpdates
+  translation: "শুধুমাত্র কিছু সিস্টেম থেকে আপডেট পান"
+- id: openDropdown
+  translation: "ড্রপডাউন খুলুন"
+- id: closeDropdown
+  translation: "ড্রপডাউন বন্ধ করুন"
+- id: automated
+  translation: "স্বয়ংক্রিয়"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "এই পোস্টটি স্বয়ংক্রিয়ভাবে তৈরি হয়েছে।"
+- id: readDocumentation
+  translation: "ডকুমেন্টেশন পড়ুন"
+- id: copied
+  translation: "কপি করা হয়েছে!"
+- id: copyToClipboard
+  translation: "ক্লিপবোর্ডে কপি করুন"
+- id: open
+  translation: "খুলুন"

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -144,7 +144,7 @@
 ##
 
 - id: averageSystemsDowntime
-  translation: সম্প্রতি, গড় ডেটার উপর ভিত্তি করে, দেখে মনে হচ্ছে এই সিস্টেমটি নিচে চলে গেছে প্রায় 
+  translation: সম্প্রতি, গড় ডেটার উপর ভিত্তি করে, দেখে মনে হচ্ছে এই সিস্টেমটি নিচে চলে গেছে প্রায়
 - id: averageSystemsDowntimeSecondPart
   translation: মিনিটের জন্য।
 
@@ -159,3 +159,9 @@
   translation: " w"
 - id: yearAgo
   translation: " year"
+
+
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "{{ .MaxAgeYears }} বছর আগে ঘটে যাওয়া ঘটনাগুলি আর দেখানো হবে না"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,5 +1,5 @@
 # German language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: de
@@ -113,7 +113,7 @@
 - id: notFoundText
   translation: Dies könnte ein Problem von unserer Seite sein. Eventuell solltest du nochmal die URL überprüfen.
 
-- id: rss
+- id: subscribeViaRss
   translation: RSS abonnieren
 - id: toAllUpdates
   translation: alle Updates
@@ -163,3 +163,67 @@
 ##
 - id: incidentMaxAgeNotice
   translation: "Keine Vorfälle anzeigen, die älter als {{ .MaxAgeYears }} Jahre sind"
+- id: loading
+  translation: "Wird geladen"
+- id: chart
+  translation: "Diagramm"
+- id: getSupport
+  translation: "Unterstützung erhalten"
+- id: subscribe
+  translation: "Abonnieren"
+- id: subscribeDescription
+  translation: "Abonnieren Sie Updates von dieser Statusseite."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-Mail"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook-URL"
+- id: embed
+  translation: "Einbetten"
+- id: embedDescription
+  translation: "Sie können diese Statusseite in Ihre eigene Website oder Anwendung einbetten. Kopieren Sie einfach den folgenden HTML-Snippet und fügen Sie ihn ein, um eine Popup-Nachricht zu erhalten, wenn es Störungen gibt:"
+- id: copy
+  translation: "Kopieren"
+- id: embedDisclaimer
+  translation: "Suchen Sie nach weiteren Informationen zu diesem Einbettungscode und wie Sie ihn verwenden können?"
+- id: learnMore
+  translation: "Hier mehr erfahren"
+- id: pushNotifications
+  translation: "Push-Benachrichtigungen"
+- id: pushNotificationsDescription
+  translation: "Sie können diese Statusseite über Push-Benachrichtigungen über Ihren Browser abonnieren. Sie müssen dies auf jedem Gerät tun, auf dem Sie Benachrichtigungen erhalten möchten. Bitte beachten Sie, dass diese Funktion von der Browserunterstützung abhängig ist und möglicherweise nicht auf allen Geräten wie erwartet funktioniert."
+- id: pushNotificationsDisclaimer
+  translation: "Wir empfehlen, eine andere Benachrichtigungsmethode zu wählen, wenn Sie kritische Updates so schnell wie möglich erhalten möchten."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Sie können unsere API verwenden, um die Informationen und Updates von dieser Statusseite in Ihre eigene Website oder Anwendung zu integrieren. Stellen Sie einfach eine GET-Anfrage an die folgende URL:"
+- id: APIdisclaimer
+  translation: "Bitte beachten Sie, dass die API möglicherweise einer Ratenbegrenzung unterliegt."
+- id: getAllUpdates
+  translation: "Alle Updates abrufen"
+- id: getSomeUpdates
+  translation: "Updates nur von einigen Systemen abrufen"
+- id: openDropdown
+  translation: "Dropdown öffnen"
+- id: closeDropdown
+  translation: "Dropdown schließen"
+- id: automated
+  translation: "Automatisiert"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Dieser Beitrag wurde automatisch generiert."
+- id: readDocumentation
+  translation: "Dokumentation lesen"
+- id: copied
+  translation: "Kopiert!"
+- id: copyToClipboard
+  translation: "In die Zwischenablage kopieren"
+- id: open
+  translation: "Öffnen"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -157,3 +157,9 @@
   translation: " Wochen." # has to include space
 - id: yearAgo
   translation: " Jahre"
+
+
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "Keine Vorfälle anzeigen, die älter als {{ .MaxAgeYears }} Jahre sind"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -159,3 +159,10 @@
   translation: " w"
 - id: yearAgo
   translation: " year"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Not showing incidents older than from {{ .MaxAgeYears }} years"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -116,7 +116,7 @@
 - id: notFoundText
   translation: This could be a problem on our part. Perhaps we moved a certain resource and now it is gone. It is also possible that the resource you are trying to view is empty. But do you also mind to double check the link?
 
-- id: rss
+- id: subscribeViaRss
   translation: Subscribe via RSS
 - id: toAllUpdates
   translation: to all updates
@@ -166,3 +166,67 @@
 
 - id: incidentMaxAgeNotice
   translation: "Not showing incidents older than from {{ .MaxAgeYears }} years"
+- id: loading
+  translation: "Loading"
+- id: chart
+  translation: "chart"
+- id: getSupport
+  translation: "Get support"
+- id: subscribe
+  translation: "Subscribe"
+- id: subscribeDescription
+  translation: "Subscribe to updates from this status page."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Email"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook URL"
+- id: embed
+  translation: "Embed"
+- id: embedDescription
+  translation: "You can embed this status page in your own website or application. Simply copy the following HTML snippet and paste it in to get a pop-up message if there are disruptions:"
+- id: copy
+  translation: "Copy"
+- id: embedDisclaimer
+  translation: "Looking for more information about this embed and how you can use it?"
+- id: learnMore
+  translation: "Learn more here"
+- id: pushNotifications
+  translation: "Push notifications"
+- id: pushNotificationsDescription
+  translation: "You can subscribe to this status page via push notifications through your browser. You will have to do this on every device you want to receive notifications on. Please note that this feature is subject to browser support and may not work on all devices as expected."
+- id: pushNotificationsDisclaimer
+  translation: "We recommend choosing a different method of notification if you need critical updates to be delivered as soon as possible."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "You can use our API to integrate the information and updates from this status page into your own website or application. Simply make a GET request to the following URL:"
+- id: APIdisclaimer
+  translation: "Please note that the API may be subject to rate limiting."
+- id: getAllUpdates
+  translation: "Get all updates"
+- id: getSomeUpdates
+  translation: "Get updates only from some systems"
+- id: openDropdown
+  translation: "Open dropdown"
+- id: closeDropdown
+  translation: "Close dropdown"
+- id: automated
+  translation: "Automated"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "This post was automatically generated."
+- id: readDocumentation
+  translation: "Read documentation"
+- id: copied
+  translation: "Copied!"
+- id: copyToClipboard
+  translation: "Copy to clipboard"
+- id: open
+  translation: "Open"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,6 +1,6 @@
 # English language file for cState
 # Official
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: en

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -152,3 +152,10 @@
   translation: " semanas"
 - id: yearAgo
   translation: " año"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "No mostrar incidentes anteriores a {{ .MaxAgeYears }} años"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -1,5 +1,5 @@
 # Spanish language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: es
@@ -109,7 +109,7 @@
 - id: notFoundText
   translation: Esto podría ser un problema de nuestra parte. Tal vez movimos un recurso y ahora se ha ido. También es posible que el recurso que está tratando de ver esté vacío. ¿Podría verificar el enlace nuevamente?
 
-- id: rss
+- id: subscribeViaRss
   translation: Suscribirse vía RSS
 - id: toAllUpdates
   translation: a todas las actualizaciones
@@ -159,3 +159,67 @@
 
 - id: incidentMaxAgeNotice
   translation: "No mostrar incidentes anteriores a {{ .MaxAgeYears }} años"
+- id: loading
+  translation: "Cargando"
+- id: chart
+  translation: "Gráfico"
+- id: getSupport
+  translation: "Obtener soporte"
+- id: subscribe
+  translation: "Suscribirse"
+- id: subscribeDescription
+  translation: "Suscríbase a las actualizaciones de esta página de estado."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Correo electrónico"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL del webhook"
+- id: embed
+  translation: "Incrustar"
+- id: embedDescription
+  translation: "Puede incrustar esta página de estado en su propio sitio web o aplicación. Simplemente copie el siguiente fragmento de HTML y péguelo para obtener un mensaje emergente si hay interrupciones:"
+- id: copy
+  translation: "Copiar"
+- id: embedDisclaimer
+  translation: "¿Busca más información sobre esta incrustación y cómo puede usarla?"
+- id: learnMore
+  translation: "Más información aquí"
+- id: pushNotifications
+  translation: "Notificaciones push"
+- id: pushNotificationsDescription
+  translation: "Puede suscribirse a esta página de estado a través de notificaciones push a través de su navegador. Tendrá que hacer esto en cada dispositivo en el que desee recibir notificaciones. Tenga en cuenta que esta función está sujeta a la compatibilidad del navegador y es posible que no funcione en todos los dispositivos como se esperaba."
+- id: pushNotificationsDisclaimer
+  translation: "Recomendamos elegir un método de notificación diferente si necesita que se entreguen actualizaciones críticas lo antes posible."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Puede usar nuestra API para integrar la información y las actualizaciones de esta página de estado en su propio sitio web o aplicación. Simplemente haga una solicitud GET a la siguiente URL:"
+- id: APIdisclaimer
+  translation: "Tenga en cuenta que la API puede estar sujeta a límites de velocidad."
+- id: getAllUpdates
+  translation: "Obtener todas las actualizaciones"
+- id: getSomeUpdates
+  translation: "Obtener actualizaciones solo de algunos sistemas"
+- id: openDropdown
+  translation: "Abrir menú desplegable"
+- id: closeDropdown
+  translation: "Cerrar menú desplegable"
+- id: automated
+  translation: "Automatizado"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Esta publicación se generó automáticamente."
+- id: readDocumentation
+  translation: "Leer documentación"
+- id: copied
+  translation: "¡Copiado!"
+- id: copyToClipboard
+  translation: "Copiar al portapapeles"
+- id: open
+  translation: "Abrir"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,5 +1,5 @@
 # French language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: fr
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: C'est peut-être une erreur de notre part. Peut-être avons-nous déplacé une certaine ressource, ce qui l'a rendu indisponible. Il est également possible que la ressource que vous essayez de visualiser soit vide. Avez-vous pris le temps de vérifier le lien ?
 
-- id: rss
+- id: subscribeViaRss
   translation: S'abonner via RSS
 - id: toAllUpdates
   translation: à toutes les mises à jour
@@ -164,3 +164,67 @@
 
 - id: incidentMaxAgeNotice
   translation: "Ne pas afficher les incidents datant de plus de {{ .MaxAgeYears }} ans"
+- id: loading
+  translation: "Chargement"
+- id: chart
+  translation: "Graphique"
+- id: getSupport
+  translation: "Obtenir de l'aide"
+- id: subscribe
+  translation: "S'abonner"
+- id: subscribeDescription
+  translation: "Abonnez-vous aux mises à jour de cette page d'état."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-mail"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL du webhook"
+- id: embed
+  translation: "Intégrer"
+- id: embedDescription
+  translation: "Vous pouvez intégrer cette page d'état dans votre propre site Web ou application. Copiez simplement le fragment HTML suivant et collez-le pour obtenir un message contextuel en cas de perturbations :"
+- id: copy
+  translation: "Copier"
+- id: embedDisclaimer
+  translation: "Vous cherchez plus d'informations sur cette intégration et comment vous pouvez l'utiliser ?"
+- id: learnMore
+  translation: "En savoir plus ici"
+- id: pushNotifications
+  translation: "Notifications push"
+- id: pushNotificationsDescription
+  translation: "Vous pouvez vous abonner à cette page d'état via des notifications push via votre navigateur. Vous devrez le faire sur chaque appareil sur lequel vous souhaitez recevoir des notifications. Veuillez noter que cette fonctionnalité est soumise à la prise en charge du navigateur et peut ne pas fonctionner sur tous les appareils comme prévu."
+- id: pushNotificationsDisclaimer
+  translation: "Nous vous recommandons de choisir un autre mode de notification si vous avez besoin que les mises à jour critiques soient livrées le plus tôt possible."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Vous pouvez utiliser notre API pour intégrer les informations et les mises à jour de cette page d'état dans votre propre site Web ou application. Faites simplement une requête GET à l'URL suivante :"
+- id: APIdisclaimer
+  translation: "Veuillez noter que l'API peut être soumise à une limitation du débit."
+- id: getAllUpdates
+  translation: "Obtenir toutes les mises à jour"
+- id: getSomeUpdates
+  translation: "Obtenir les mises à jour uniquement de certains systèmes"
+- id: openDropdown
+  translation: "Ouvrir le menu déroulant"
+- id: closeDropdown
+  translation: "Fermer le menu déroulant"
+- id: automated
+  translation: "Automatisé"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Cet article a été généré automatiquement."
+- id: readDocumentation
+  translation: "Lire la documentation"
+- id: copied
+  translation: "Copié !"
+- id: copyToClipboard
+  translation: "Copier dans le presse-papiers"
+- id: open
+  translation: "Ouvrir"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -131,7 +131,7 @@
   translation: rubriques
 - id: newestToOldest
   translation: du plus récent au plus ancien
-  
+
 ##
 ## v4
 ##
@@ -140,7 +140,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: D'après les données moyennes, il semble que ce système ait été indisponible pendant environ
@@ -157,3 +157,10 @@
   translation: " sem"
 - id: yearAgo
   translation: " années"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Ne pas afficher les incidents datant de plus de {{ .MaxAgeYears }} ans"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -1,5 +1,5 @@
 # Indonesian language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: id
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: Mungkin ini masalah kami. Barangkali ada informasi yang telah kami pindahkan, atau boleh jadi informasi yang Anda ingin lihat kosong. Namun bisakah Anda coba periksa ulang tautannya?
 
-- id: rss
+- id: subscribeViaRss
   translation: Langganan via RSS
 - id: toAllUpdates
   translation: untuk semua pembaruan
@@ -158,3 +158,74 @@
   translation: " minggu"
 - id: yearAgo
   translation: " tahun"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Tidak menampilkan insiden yang lebih lama dari {{ .MaxAgeYears }} tahun"
+- id: loading
+  translation: "Memuat"
+- id: chart
+  translation: "Grafik"
+- id: getSupport
+  translation: "Dapatkan dukungan"
+- id: subscribe
+  translation: "Berlangganan"
+- id: subscribeDescription
+  translation: "Berlangganan pembaruan dari halaman status ini."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Email"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL Webhook"
+- id: embed
+  translation: "Sematkan"
+- id: embedDescription
+  translation: "Anda dapat menyematkan halaman status ini di situs web atau aplikasi Anda sendiri. Cukup salin cuplikan HTML berikut dan tempelkan untuk mendapatkan pesan pop-up jika ada gangguan:"
+- id: copy
+  translation: "Salin"
+- id: embedDisclaimer
+  translation: "Mencari informasi lebih lanjut tentang sematan ini dan bagaimana Anda dapat menggunakannya?"
+- id: learnMore
+  translation: "Pelajari lebih lanjut di sini"
+- id: pushNotifications
+  translation: "Notifikasi Push"
+- id: pushNotificationsDescription
+  translation: "Anda dapat berlangganan halaman status ini melalui notifikasi push melalui browser Anda. Anda harus melakukan ini di setiap perangkat yang ingin Anda terima notifikasinya. Harap perhatikan bahwa fitur ini bergantung pada dukungan browser dan mungkin tidak berfungsi di semua perangkat seperti yang diharapkan."
+- id: pushNotificationsDisclaimer
+  translation: "Kami merekomendasikan untuk memilih metode notifikasi yang berbeda jika Anda membutuhkan pembaruan kritis untuk dikirimkan sesegera mungkin."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Anda dapat menggunakan API kami untuk mengintegrasikan informasi dan pembaruan dari halaman status ini ke situs web atau aplikasi Anda sendiri. Cukup buat permintaan GET ke URL berikut:"
+- id: APIdisclaimer
+  translation: "Harap perhatikan bahwa API mungkin dikenakan pembatasan tarif."
+- id: getAllUpdates
+  translation: "Dapatkan semua pembaruan"
+- id: getSomeUpdates
+  translation: "Dapatkan pembaruan hanya dari beberapa sistem"
+- id: openDropdown
+  translation: "Buka dropdown"
+- id: closeDropdown
+  translation: "Tutup dropdown"
+- id: automated
+  translation: "Otomatis"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Postingan ini dibuat secara otomatis."
+- id: readDocumentation
+  translation: "Baca dokumentasi"
+- id: copied
+  translation: "Disalin!"
+- id: copyToClipboard
+  translation: "Salin ke clipboard"
+- id: open
+  translation: "Buka"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -1,5 +1,5 @@
 # Italian language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: it
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: Questo potrebbe essere un problema da parte nostra. Forse abbiamo spostato una risorsa e ora non c'è più. È anche possibile che la risorsa che stai cercando di visualizzare sia vuota. Ti dispiace ricontrollare l'indirizzo?
 
-- id: rss
+- id: subscribeViaRss
   translation: Sottoscriviti tramite RSS
 - id: toAllUpdates
   translation: per tutti gli aggiornamenti
@@ -158,3 +158,74 @@
   translation: " sett"
 - id: yearAgo
   translation: " anni"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Non mostrare incidenti più vecchi di {{ .MaxAgeYears }} anni"
+- id: loading
+  translation: "Caricamento"
+- id: chart
+  translation: "Grafico"
+- id: getSupport
+  translation: "Ottieni supporto"
+- id: subscribe
+  translation: "Iscriviti"
+- id: subscribeDescription
+  translation: "Iscriviti agli aggiornamenti da questa pagina di stato."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Email"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL Webhook"
+- id: embed
+  translation: "Incorpora"
+- id: embedDescription
+  translation: "Puoi incorporare questa pagina di stato nel tuo sito web o applicazione. Copia semplicemente il seguente snippet HTML e incollalo per ottenere un messaggio pop-up in caso di interruzioni:"
+- id: copy
+  translation: "Copia"
+- id: embedDisclaimer
+  translation: "Cerchi maggiori informazioni su questo incorporamento e su come puoi usarlo?"
+- id: learnMore
+  translation: "Scopri di più qui"
+- id: pushNotifications
+  translation: "Notifiche push"
+- id: pushNotificationsDescription
+  translation: "Puoi iscriverti a questa pagina di stato tramite notifiche push tramite il tuo browser. Dovrai farlo su ogni dispositivo su cui desideri ricevere le notifiche. Tieni presente che questa funzione è soggetta al supporto del browser e potrebbe non funzionare su tutti i dispositivi come previsto."
+- id: pushNotificationsDisclaimer
+  translation: "Ti consigliamo di scegliere un metodo di notifica diverso se hai bisogno di aggiornamenti critici da consegnare il prima possibile."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Puoi utilizzare la nostra API per integrare le informazioni e gli aggiornamenti da questa pagina di stato nel tuo sito Web o applicazione. Effettua semplicemente una richiesta GET al seguente URL:"
+- id: APIdisclaimer
+  translation: "Si prega di notare che l'API potrebbe essere soggetta a limitazioni di velocità."
+- id: getAllUpdates
+  translation: "Ricevi tutti gli aggiornamenti"
+- id: getSomeUpdates
+  translation: "Ricevi aggiornamenti solo da alcuni sistemi"
+- id: openDropdown
+  translation: "Apri menu a tendina"
+- id: closeDropdown
+  translation: "Chiudi menu a tendina"
+- id: automated
+  translation: "Automatizzato"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Questo post è stato generato automaticamente."
+- id: readDocumentation
+  translation: "Leggi la documentazione"
+- id: copied
+  translation: "Copiato!"
+- id: copyToClipboard
+  translation: "Copia negli appunti"
+- id: open
+  translation: "Apri"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,5 +1,5 @@
 # Japanese language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: ja
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: これは私たちに問題があるかもしれません。おそらくページを移動したら、それが無くなってしまったのでしょう。リンク先をもう一度ご確認ください。
 
-- id: rss
+- id: subscribeViaRss
   translation: RSS
 - id: toAllUpdates
   translation: 全てのアップデートを購読
@@ -158,3 +158,74 @@
   translation: " 週間前"
 - id: yearAgo
   translation: " 年前"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "{{ .MaxAgeYears }} 年以上前のインシデントは表示しません"
+- id: loading
+  translation: "読み込み中"
+- id: chart
+  translation: "チャート"
+- id: getSupport
+  translation: "サポートを受ける"
+- id: subscribe
+  translation: "購読"
+- id: subscribeDescription
+  translation: "このステータスページの更新を購読します。"
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "メール"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook URL"
+- id: embed
+  translation: "埋め込み"
+- id: embedDescription
+  translation: "このステータスページを自分のウェブサイトやアプリケーションに埋め込むことができます。障害が発生した場合にポップアップメッセージを表示するには、次の HTML スニペットをコピーして貼り付けてください:"
+- id: copy
+  translation: "コピー"
+- id: embedDisclaimer
+  translation: "この埋め込みに関する詳細と使用方法については、こちらをご覧ください。"
+- id: learnMore
+  translation: "詳細はこちら"
+- id: pushNotifications
+  translation: "プッシュ通知"
+- id: pushNotificationsDescription
+  translation: "ブラウザのプッシュ通知を介して、このステータスページを購読できます。通知を受信するすべてのデバイスでこれを行う必要があります。この機能はブラウザのサポート対象であり、すべてのデバイスで期待どおりに動作しない場合があることに注意してください。"
+- id: pushNotificationsDisclaimer
+  translation: "重要な更新をできるだけ早く配信する必要がある場合は、別の通知方法を選択することをお勧めします。"
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "API を使用して、このステータスページの情報と更新を自分のウェブサイトやアプリケーションに統合できます。次の URL に GET リクエストを送信してください:"
+- id: APIdisclaimer
+  translation: "API にはレート制限が適用される場合があることに注意してください。"
+- id: getAllUpdates
+  translation: "すべての更新を取得する"
+- id: getSomeUpdates
+  translation: "一部のシステムからのみ更新を取得する"
+- id: openDropdown
+  translation: "ドロップダウンを開く"
+- id: closeDropdown
+  translation: "ドロップダウンを閉じる"
+- id: automated
+  translation: "自動化"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "この投稿は自動的に生成されました。"
+- id: readDocumentation
+  translation: "ドキュメントを読む"
+- id: copied
+  translation: "コピーしました！"
+- id: copyToClipboard
+  translation: "クリップボードにコピー"
+- id: open
+  translation: "開く"

--- a/i18n/lt.yaml
+++ b/i18n/lt.yaml
@@ -3,7 +3,7 @@
 # Version 4.4
 
 - id: languageCode
-  translation: en
+  translation: lt
 - id: languageName
   translation: Lithuanian
 - id: languageNameShort
@@ -45,8 +45,8 @@
   translation: Paskutinį kartą atnaujinta prieš
 - id: justNow
   translation: <5s
-# - id: someTimeAgo
-#   translation: # not used
+- id: someTimeAgo
+  translation: ""
 
 # Example usage: `5` + `years`
 # Final result: 'Last checked 5 years ago'
@@ -79,9 +79,9 @@
 - id: inUnderAMinute
   translation: minutės # continuing the last string
 - id: resolvedAfter
-  translation: Išspręsta problema po # + 19 min # not used
-#- id: ofDowntime
-#  translation: of downtime
+  translation: Išspręsta problema po # + 19 min
+- id: ofDowntime
+  translation: neveikimo laiko
 
 - id: downtimeOngoing
   translation: Dar sprendžiama problema
@@ -116,8 +116,8 @@
 - id: notFoundText
   translation: Tai gali būti mūsų problema — galbūt puslapis, kurį bandote peržiūrėti, buvo kitur perkeltas arba buvo ištrintas. Rekomenduoje dar kartą patikrinti, ar nuoroda, kurią naudojate, nėra neteisinga.
 
-- id: rss
-  translation: Gaukite atnaujinimus naudojant RSS
+- id: subscribeViaRss
+  translation: Prenumeruoti per RSS
 - id: toAllUpdates
   translation: visi atnaujinimai
 - id: or
@@ -154,13 +154,79 @@
 ##
 
 - id: in
-  translation: in
+  translation: per
 - id: weeksAgo
-  translation: " sav." # has to include space
+  translation: " sav."
 - id: yearAgo
   translation: " metus"
 
+##
 ## v6
 ##
-- id: maxAgeYears
-  translation: "Nerodomi įvykiai, senesni nei {{ .MaxAgeYears }} metai"
+
+- id: incidentMaxAgeNotice
+  translation: "Nerodomi įvykiai, senesni nei {{ .MaxAgeYears }} met."
+- id: loading
+  translation: "Įkeliama"
+- id: chart
+  translation: "grafikas"
+- id: getSupport
+  translation: "Gauti pagalbą"
+- id: subscribe
+  translation: "Gauti pranešimus"
+- id: subscribeDescription
+  translation: "Gaukite žinutes, kai šis puslapis atsinaujina su nauja informacija."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "El. paštas"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook URL"
+- id: embed
+  translation: "Įterpti"
+- id: embedDescription
+  translation: "Galite įterpti šį puslapį į savo programą ar internetinį puslapį. Tiesiog nukopijuokite šį HTML fragmentą ir įklijuokite jį, kad gautumėte iššokantį pranešimą, jei yra sutrikimų:"
+- id: copy
+  translation: "Kopijuoti"
+- id: embedDisclaimer
+  translation: "Ieškote daugiau informacijos apie šį įterpimą ir kaip jį naudoti?"
+- id: learnMore
+  translation: "Sužinokite daugiau čia"
+- id: pushNotifications
+  translation: "Tiesioginiai pranešimai"
+- id: pushNotificationsDescription
+  translation: "Galite gauti pranešimus apie pokyčius šiame puslapyje per tiesioginius pranešimus savo naršyklėje. Kiekviename įrenginyje, kuriame norite gauti pranešimus, turėsite įjungti žinutes. Atkreipkite dėmesį, kad ši funkcija priklauso nuo naršyklės palaikymo ir gali veikti ne visuose įrenginiuose, kaip tikėtasi."
+- id: pushNotificationsDisclaimer
+  translation: "Rekomenduojame pasirinkti kitą pranešimų būdą, jei jums reikia, kad kritiniai atnaujinimai būtų pristatyti kuo greičiau."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Galite naudoti mūsų API, kad integruotumėte informaciją ir atnaujinimus iš šio puslapio į savo svetainę ar programą. Tiesiog atlikite GET užklausą šiuo URL:"
+- id: APIdisclaimer
+  translation: "Atkreipkite dėmesį, kad API gali būti taikomi apribojimai."
+- id: getAllUpdates
+  translation: "Gauti visus atnaujinimus"
+- id: getSomeUpdates
+  translation: "Gauti atnaujinimus tik iš kai kurių sistemų"
+- id: openDropdown
+  translation: "Atidaryti išskleidžiamąjį meniu"
+- id: closeDropdown
+  translation: "Uždaryti išskleidžiamąjį meniu"
+- id: automated
+  translation: "Automatizuota"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Šis įrašas buvo sugeneruotas automatiškai."
+- id: readDocumentation
+  translation: "Skaityti dokumentaciją"
+- id: copied
+  translation: "Nukopijuota!"
+- id: copyToClipboard
+  translation: "Kopijuoti į iškarpinę"
+- id: open
+  translation: "Atidaryti"

--- a/i18n/lt.yaml
+++ b/i18n/lt.yaml
@@ -141,7 +141,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Pastaruoju metu, regis, šis komponentas sutrikimų metu neveikia apie
@@ -159,3 +159,8 @@
   translation: " sav." # has to include space
 - id: yearAgo
   translation: " metus"
+
+## v6
+##
+- id: maxAgeYears
+  translation: "Nerodomi įvykiai, senesni nei {{ .MaxAgeYears }} metai"

--- a/i18n/mk.yaml
+++ b/i18n/mk.yaml
@@ -1,5 +1,5 @@
 # Macedonian language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: mk
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: Ова може да е проблем на нашата страна. Можеби преместивме некои ресурси и сега ги нема. Можни ресурсот што пробувате да го пристапите е празен. Ве молиме проверите го линкот повторно.
 
-- id: rss
+- id: subscribeViaRss
   translation: Претплатете се со RSS
 - id: toAllUpdates
   translation: за сите најави
@@ -140,7 +140,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Во последно време, врз основа на просечни податици, овој систем се сметал паднат за околу
@@ -157,3 +157,74 @@
   translation: " н"
 - id: yearAgo
   translation: " г"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Не се прикажуваат инциденти постари од {{ .MaxAgeYears }} години"
+- id: loading
+  translation: "Се вчитува"
+- id: chart
+  translation: "Графикон"
+- id: getSupport
+  translation: "Добијте поддршка"
+- id: subscribe
+  translation: "Претплатете се"
+- id: subscribeDescription
+  translation: "Претплатете се на ажурирања од оваа страница за статус."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Е-пошта"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook URL"
+- id: embed
+  translation: "Вметни"
+- id: embedDescription
+  translation: "Можете да ја вметнете оваа страница за статус во вашата сопствена веб-страница или апликација. Едноставно копирајте го следниов HTML исечок и залепете го за да добиете скокачка порака доколку има прекини:"
+- id: copy
+  translation: "Копирај"
+- id: embedDisclaimer
+  translation: "Барате повеќе информации за ова вметнување и како можете да го користите?"
+- id: learnMore
+  translation: "Дознајте повеќе овде"
+- id: pushNotifications
+  translation: "Push известувања"
+- id: pushNotificationsDescription
+  translation: "Можете да се претплатите на оваа страница за статус преку push известувања преку вашиот прелистувач. Ќе треба да го направите ова на секој уред на кој сакате да примате известувања. Ве молиме имајте предвид дека оваа функција е предмет на поддршка од прелистувачот и може да не работи на сите уреди како што се очекува."
+- id: pushNotificationsDisclaimer
+  translation: "Препорачуваме да изберете различен метод на известување доколку ви требаат критичните ажурирања да бидат испорачани што е можно поскоро."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Можете да го користите нашиот API за да ги интегрирате информациите и ажурирањата од оваа страница за статус во вашата сопствена веб-страница или апликација. Едноставно направете GET барање до следнава URL-адреса:"
+- id: APIdisclaimer
+  translation: "Ве молиме имајте предвид дека API може да биде предмет на ограничување на стапката."
+- id: getAllUpdates
+  translation: "Добијте ги сите ажурирања"
+- id: getSomeUpdates
+  translation: "Добијте ажурирања само од некои системи"
+- id: openDropdown
+  translation: "Отвори паѓачко мени"
+- id: closeDropdown
+  translation: "Затвори паѓачко мени"
+- id: automated
+  translation: "Автоматизирано"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Овој пост беше автоматски генериран."
+- id: readDocumentation
+  translation: "Прочитајте ја документацијата"
+- id: copied
+  translation: "Копирано!"
+- id: copyToClipboard
+  translation: "Копирај во таблата со исечоци"
+- id: open
+  translation: "Отвори"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,5 +1,5 @@
 # Dutch language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: nl
@@ -113,7 +113,7 @@
   translation: Hier is niets.
 - id: notFoundText
   translation: Dit kan een fout zijn aan onze kant. Misschien hebben we de bron verplaats en nu is het weg. Het kan ook dat je de bron die je probeert te bekijken leeg is. Wil je mischien even de url checken?
-- id: rss
+- id: subscribeViaRss
   translation: Abonneer via RSS
 - id: toAllUpdates
   translation: op alle updates
@@ -137,7 +137,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Recentelijk, gebaseerd op gemiddelde downtime, is het systeem ofline geweest voor ongeveer
@@ -154,3 +154,74 @@
   translation: " w"
 - id: yearAgo
   translation: " jaar"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Incidenten ouder dan {{ .MaxAgeYears }} jaar worden niet weergegeven"
+- id: loading
+  translation: "Laden"
+- id: chart
+  translation: "Grafiek"
+- id: getSupport
+  translation: "Krijg ondersteuning"
+- id: subscribe
+  translation: "Abonneren"
+- id: subscribeDescription
+  translation: "Abonneer je op updates van deze statuspagina."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-mail"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook-URL"
+- id: embed
+  translation: "Insluiten"
+- id: embedDescription
+  translation: "U kunt deze statuspagina insluiten in uw eigen website of applicatie. Kopieer eenvoudig het volgende HTML-fragment en plak het om een pop-upbericht te krijgen als er storingen zijn:"
+- id: copy
+  translation: "Kopiëren"
+- id: embedDisclaimer
+  translation: "Op zoek naar meer informatie over deze insluiting en hoe u deze kunt gebruiken?"
+- id: learnMore
+  translation: "Meer informatie hier"
+- id: pushNotifications
+  translation: "Pushmeldingen"
+- id: pushNotificationsDescription
+  translation: "U kunt zich abonneren op deze statuspagina via pushmeldingen via uw browser. U moet dit doen op elk apparaat waarop u meldingen wilt ontvangen. Houd er rekening mee dat deze functie afhankelijk is van browserondersteuning en mogelijk niet op alle apparaten werkt zoals verwacht."
+- id: pushNotificationsDisclaimer
+  translation: "We raden aan om een andere meldingsmethode te kiezen als u kritieke updates zo snel mogelijk wilt ontvangen."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "U kunt onze API gebruiken om de informatie en updates van deze statuspagina te integreren in uw eigen website of applicatie. Maak eenvoudig een GET-verzoek naar de volgende URL:"
+- id: APIdisclaimer
+  translation: "Houd er rekening mee dat de API mogelijk onderhevig is aan snelheidsbeperkingen."
+- id: getAllUpdates
+  translation: "Ontvang alle updates"
+- id: getSomeUpdates
+  translation: "Ontvang alleen updates van sommige systemen"
+- id: openDropdown
+  translation: "Open dropdown"
+- id: closeDropdown
+  translation: "Sluit dropdown"
+- id: automated
+  translation: "Geautomatiseerd"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Dit bericht is automatisch gegenereerd."
+- id: readDocumentation
+  translation: "Lees documentatie"
+- id: copied
+  translation: "Gekopieerd!"
+- id: copyToClipboard
+  translation: "Kopieer naar klembord"
+- id: open
+  translation: "Open"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -1,5 +1,5 @@
 # Polish language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: pl
@@ -20,7 +20,7 @@
 - id: isNotice
   translation: Ogłoszenie
 - id: isOk
-  translation: Wszystkie systemy sprawne 
+  translation: Wszystkie systemy sprawne
 
 # No JS warning
 - id: noScriptingIntro
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: To może być problem z naszej strony. Być może przenieśliśmy określony zasób i teraz go nie ma. Możliwe jest również, że zasób, który próbujesz wyświetlić, jest pusty. Ale czy masz też coś przeciwko, aby dwukrotnie sprawdzić link?
 
-- id: rss
+- id: subscribeViaRss
   translation: Subskrybuj przez RSS
 - id: toAllUpdates
   translation: wszystkie zdarzenia
@@ -158,3 +158,74 @@
   translation: " tyg"
 - id: yearAgo
   translation: " y"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Nie pokazuj zdarzeń starszych niż {{ .MaxAgeYears }} lat"
+- id: loading
+  translation: "Ładowanie"
+- id: chart
+  translation: "Wykres"
+- id: getSupport
+  translation: "Uzyskaj wsparcie"
+- id: subscribe
+  translation: "Subskrybuj"
+- id: subscribeDescription
+  translation: "Subskrybuj aktualizacje ze strony stanu."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-mail"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Adres URL elementu webhook"
+- id: embed
+  translation: "Osadź"
+- id: embedDescription
+  translation: "Możesz osadzić tę stronę stanu we własnej witrynie lub aplikacji. Po prostu skopiuj poniższy fragment kodu HTML i wklej go, aby otrzymać wyskakujące okienko w przypadku wystąpienia zakłóceń:"
+- id: copy
+  translation: "Kopiuj"
+- id: embedDisclaimer
+  translation: "Szukasz więcej informacji o tym osadzeniu i jak możesz go użyć?"
+- id: learnMore
+  translation: "Dowiedz się więcej tutaj"
+- id: pushNotifications
+  translation: "Powiadomienia push"
+- id: pushNotificationsDescription
+  translation: "Możesz subskrybować tę stronę stanu za pomocą powiadomień push w przeglądarce. Musisz to zrobić na każdym urządzeniu, na którym chcesz otrzymywać powiadomienia. Pamiętaj, że ta funkcja jest zależna od obsługi przeglądarki i może nie działać na wszystkich urządzeniach zgodnie z oczekiwaniami."
+- id: pushNotificationsDisclaimer
+  translation: "Zalecamy wybranie innej metody powiadomień, jeśli potrzebujesz, aby krytyczne aktualizacje były dostarczane jak najszybciej."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Możesz użyć naszego API, aby zintegrować informacje i aktualizacje z tej strony stanu z własną witryną lub aplikacją. Po prostu wyślij żądanie GET do następującego adresu URL:"
+- id: APIdisclaimer
+  translation: "Pamiętaj, że API może podlegać ograniczeniom szybkości."
+- id: getAllUpdates
+  translation: "Pobierz wszystkie aktualizacje"
+- id: getSomeUpdates
+  translation: "Pobierz aktualizacje tylko z niektórych systemów"
+- id: openDropdown
+  translation: "Otwórz menu rozwijane"
+- id: closeDropdown
+  translation: "Zamknij menu rozwijane"
+- id: automated
+  translation: "Automatyczne"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Ten post został wygenerowany automatycznie."
+- id: readDocumentation
+  translation: "Przeczytaj dokumentację"
+- id: copied
+  translation: "Skopiowano!"
+- id: copyToClipboard
+  translation: "Kopiuj do schowka"
+- id: open
+  translation: "Otwórz"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -1,5 +1,5 @@
 # Portuguese language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: pt
@@ -115,7 +115,7 @@
 - id: notFoundText
   translation: Isso pode ser um problema da nossa parte. Talvez tenhamos movido um determinado recurso e agora ele se foi. Também é possível que o recurso que você está tentando visualizar esteja vazio. Mas você se importa de verificar o link?
 
-- id: rss
+- id: subscribeViaRss
   translation: Se increva via RSS
 - id: toAllUpdates
   translation: para todas as atualizações
@@ -140,7 +140,7 @@
 
 ##
 ## v4.1
-## 
+##
 
 - id: averageSystemsDowntime
   translation: Recentemente, por dados médicos para que esse sistema caiu por
@@ -157,3 +157,73 @@
   translation: " semanas"
 - id: yearAgo
   translation: " ano"
+
+##
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "Não mostrando incidentes anteriores a {{ .MaxAgeYears }} anos"
+- id: loading
+  translation: "Carregando"
+- id: chart
+  translation: "Gráfico"
+- id: getSupport
+  translation: "Obter suporte"
+- id: subscribe
+  translation: "Inscrever-se"
+- id: subscribeDescription
+  translation: "Inscreva-se para receber atualizações desta página de status."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-mail"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL do Webhook"
+- id: embed
+  translation: "Incorporar"
+- id: embedDescription
+  translation: "Você pode incorporar esta página de status em seu próprio site ou aplicativo. Basta copiar o seguinte trecho de HTML e colá-lo para obter uma mensagem pop-up se houver interrupções:"
+- id: copy
+  translation: "Copiar"
+- id: embedDisclaimer
+  translation: "Procurando mais informações sobre esta incorporação e como você pode usá-la?"
+- id: learnMore
+  translation: "Saiba mais aqui"
+- id: pushNotifications
+  translation: "Notificações push"
+- id: pushNotificationsDescription
+  translation: "Você pode se inscrever nesta página de status por meio de notificações push por meio de seu navegador. Você terá que fazer isso em todos os dispositivos em que deseja receber notificações. Observe que esse recurso está sujeito ao suporte do navegador e pode não funcionar em todos os dispositivos como esperado."
+- id: pushNotificationsDisclaimer
+  translation: "Recomendamos escolher um método de notificação diferente se você precisar que as atualizações críticas sejam entregues o mais rápido possível."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Você pode usar nossa API para integrar as informações e atualizações desta página de status em seu próprio site ou aplicativo. Basta fazer uma solicitação GET para o seguinte URL:"
+- id: APIdisclaimer
+  translation: "Observe que a API pode estar sujeita a limitação de taxa."
+- id: getAllUpdates
+  translation: "Obter todas as atualizações"
+- id: getSomeUpdates
+  translation: "Obter atualizações apenas de alguns sistemas"
+- id: openDropdown
+  translation: "Abrir menu suspenso"
+- id: closeDropdown
+  translation: "Fechar menu suspenso"
+- id: automated
+  translation: "Automatizado"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Esta postagem foi gerada automaticamente."
+- id: readDocumentation
+  translation: "Ler documentação"
+- id: copied
+  translation: "Copiado!"
+- id: copyToClipboard
+  translation: "Copiar para a área de transferência"
+- id: open
+  translation: "Abrir"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -1,6 +1,6 @@
 # Russian language file for cState
 # Official
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: ru
@@ -116,7 +116,7 @@
 - id: notFoundText
   translation: Возможно, это наша проблема. Может быть, мы переместили какой-то ресурс, и теперь он недоступен. Возможно также, что ресурс, который вы пытаетесь просмотреть, пуст. Не могли бы вы также дважды проверить ссылку?
 
-- id: rss
+- id: subscribeViaRss
   translation: Подписаться через RSS
 - id: toAllUpdates
   translation: на все обновления
@@ -159,3 +159,74 @@
   translation: " нед."
 - id: yearAgo
   translation: " год"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Не показывать инциденты старше {{ .MaxAgeYears }} лет"
+- id: loading
+  translation: "Загрузка"
+- id: chart
+  translation: "График"
+- id: getSupport
+  translation: "Получить поддержку"
+- id: subscribe
+  translation: "Подписаться"
+- id: subscribeDescription
+  translation: "Подпишитесь на обновления с этой страницы состояния."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Электронная почта"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL-адрес веб-перехватчика"
+- id: embed
+  translation: "Встроить"
+- id: embedDescription
+  translation: "Вы можете встроить эту страницу состояния в свой собственный веб-сайт или приложение. Просто скопируйте следующий фрагмент HTML и вставьте его, чтобы получать всплывающее сообщение, если есть сбои:"
+- id: copy
+  translation: "Копировать"
+- id: embedDisclaimer
+  translation: "Ищете дополнительную информацию об этом встраивании и о том, как вы можете его использовать?"
+- id: learnMore
+  translation: "Узнать больше здесь"
+- id: pushNotifications
+  translation: "Push-уведомления"
+- id: pushNotificationsDescription
+  translation: "Вы можете подписаться на эту страницу состояния через push-уведомления через свой браузер. Вам нужно будет сделать это на каждом устройстве, на котором вы хотите получать уведомления. Обратите внимание, что эта функция зависит от поддержки браузера и может работать не на всех устройствах должным образом."
+- id: pushNotificationsDisclaimer
+  translation: "Мы рекомендуем выбрать другой способ уведомления, если вам нужно, чтобы критические обновления доставлялись как можно скорее."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Вы можете использовать наш API для интеграции информации и обновлений с этой страницы состояния в свой собственный веб-сайт или приложение. Просто сделайте GET-запрос по следующему URL-адресу:"
+- id: APIdisclaimer
+  translation: "Обратите внимание, что API может подвергаться ограничению скорости."
+- id: getAllUpdates
+  translation: "Получить все обновления"
+- id: getSomeUpdates
+  translation: "Получать обновления только от некоторых систем"
+- id: openDropdown
+  translation: "Открыть раскрывающийся список"
+- id: closeDropdown
+  translation: "Закрыть раскрывающийся список"
+- id: automated
+  translation: "Автоматически"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Это сообщение было сгенерировано автоматически."
+- id: readDocumentation
+  translation: "Прочитать документацию"
+- id: copied
+  translation: "Скопировано!"
+- id: copyToClipboard
+  translation: "Копировать в буфер обмена"
+- id: open
+  translation: "Открыть"

--- a/i18n/se.yaml
+++ b/i18n/se.yaml
@@ -1,5 +1,5 @@
 # Swedish language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: se
@@ -113,7 +113,7 @@
 - id: notFoundText
   translation: Detta kan vara ett problem från vår sida. Kanske har vi flyttat en viss resurs och nu är den borta. Det är också möjligt att resursen du försöker visa är tom. Men har du också något emot att dubbelkolla länken?
 
-- id: rss
+- id: subscribeViaRss
   translation: Prenumerera via RSS
 - id: toAllUpdates
   translation: till alla uppdateringar
@@ -155,3 +155,73 @@
   translation: " v"
 - id: yearAgo
   translation: " år"
+
+##
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "Visar inte incidenter äldre än {{ .MaxAgeYears }} år"
+- id: loading
+  translation: "Laddar"
+- id: chart
+  translation: "Diagram"
+- id: getSupport
+  translation: "Få support"
+- id: subscribe
+  translation: "Prenumerera"
+- id: subscribeDescription
+  translation: "Prenumerera på uppdateringar från denna statussida."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-post"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook-URL"
+- id: embed
+  translation: "Bädda in"
+- id: embedDescription
+  translation: "Du kan bädda in den här statussidan på din egen webbplats eller applikation. Kopiera bara följande HTML-kodavsnitt och klistra in det för att få ett popup-meddelande om det finns störningar:"
+- id: copy
+  translation: "Kopiera"
+- id: embedDisclaimer
+  translation: "Letar du efter mer information om den här inbäddningen och hur du kan använda den?"
+- id: learnMore
+  translation: "Läs mer här"
+- id: pushNotifications
+  translation: "Push-notiser"
+- id: pushNotificationsDescription
+  translation: "Du kan prenumerera på den här statussidan via push-notiser via din webbläsare. Du måste göra detta på alla enheter du vill få notiser på. Observera att den här funktionen är beroende av webbläsarstöd och kanske inte fungerar på alla enheter som förväntat."
+- id: pushNotificationsDisclaimer
+  translation: "Vi rekommenderar att du väljer en annan aviseringsmetod om du behöver kritiska uppdateringar levereras så snart som möjligt."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Du kan använda vårt API för att integrera informationen och uppdateringarna från denna statussida i din egen webbplats eller applikation. Gör bara en GET-förfrågan till följande URL:"
+- id: APIdisclaimer
+  translation: "Observera att API:et kan vara föremål för hastighetsbegränsning."
+- id: getAllUpdates
+  translation: "Få alla uppdateringar"
+- id: getSomeUpdates
+  translation: "Få endast uppdateringar från vissa system"
+- id: openDropdown
+  translation: "Öppna rullgardinsmenyn"
+- id: closeDropdown
+  translation: "Stäng rullgardinsmenyn"
+- id: automated
+  translation: "Automatiserad"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Det här inlägget genererades automatiskt."
+- id: readDocumentation
+  translation: "Läs dokumentation"
+- id: copied
+  translation: "Kopierat!"
+- id: copyToClipboard
+  translation: "Kopiera till urklipp"
+- id: open
+  translation: "Öppna"

--- a/i18n/tl.yaml
+++ b/i18n/tl.yaml
@@ -1,5 +1,5 @@
 # Tagalog language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: tl
@@ -114,7 +114,7 @@
 - id: notFoundText
   translation: Ito'y maaaring problema sa amin. Maaring may nilipat kami na resors at ngayon ay nawala na ito. Posible din na ang resors na nais mong makita ay walang laman. Pero, ayos lang ba sa iyo ang dobol-check sa link?
 
-- id: rss
+- id: subscribeViaRss
   translation: Mag-subskrayb sa pamamagitan ng RSS
 - id: toAllUpdates
   translation: sa lahat ng mga updeyt
@@ -157,3 +157,74 @@
   translation: " l"
 - id: yearAgo
   translation: " taon"
+
+##
+## v6
+##
+
+- id: incidentMaxAgeNotice
+  translation: "Hindi ipinapakita ang mga insidente na mas matanda sa {{ .MaxAgeYears }} taon"
+- id: loading
+  translation: "Naglo-load"
+- id: chart
+  translation: "Tsart"
+- id: getSupport
+  translation: "Kumuha ng suporta"
+- id: subscribe
+  translation: "Mag-subscribe"
+- id: subscribeDescription
+  translation: "Mag-subscribe sa mga update mula sa pahina ng katayuan na ito."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Email"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL ng Webhook"
+- id: embed
+  translation: "I-embed"
+- id: embedDescription
+  translation: "Maaari mong i-embed ang pahina ng katayuan na ito sa iyong sariling website o application. Kopyahin lamang ang sumusunod na snippet ng HTML at i-paste ito upang makakuha ng pop-up na mensahe kung mayroong mga pagkaantala:"
+- id: copy
+  translation: "Kopyahin"
+- id: embedDisclaimer
+  translation: "Naghahanap ng higit pang impormasyon tungkol sa embed na ito at kung paano mo ito magagamit?"
+- id: learnMore
+  translation: "Matuto pa dito"
+- id: pushNotifications
+  translation: "Mga push notification"
+- id: pushNotificationsDescription
+  translation: "Maaari kang mag-subscribe sa pahina ng katayuan na ito sa pamamagitan ng mga push notification sa iyong browser. Kakailanganin mong gawin ito sa bawat device na gusto mong makatanggap ng mga notification. Pakitandaan na ang feature na ito ay napapailalim sa suporta ng browser at maaaring hindi gumana sa lahat ng device gaya ng inaasahan."
+- id: pushNotificationsDisclaimer
+  translation: "Inirerekomenda naming pumili ng ibang paraan ng notification kung kailangan mong maihatid ang mga kritikal na update sa lalong madaling panahon."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Maaari mong gamitin ang aming API upang isama ang impormasyon at mga update mula sa pahina ng katayuan na ito sa iyong sariling website o application. Gumawa lamang ng kahilingan sa GET sa sumusunod na URL:"
+- id: APIdisclaimer
+  translation: "Pakitandaan na ang API ay maaaring sumailalim sa paglilimita sa rate."
+- id: getAllUpdates
+  translation: "Kunin ang lahat ng update"
+- id: getSomeUpdates
+  translation: "Kumuha ng mga update mula sa ilang system lamang"
+- id: openDropdown
+  translation: "Buksan ang dropdown"
+- id: closeDropdown
+  translation: "Isara ang dropdown"
+- id: automated
+  translation: "Awtomatiko"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Awtomatikong nabuo ang post na ito."
+- id: readDocumentation
+  translation: "Basahin ang dokumentasyon"
+- id: copied
+  translation: "Kinopya!"
+- id: copyToClipboard
+  translation: "Kopyahin sa clipboard"
+- id: open
+  translation: "Buksan"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -1,5 +1,5 @@
 # Turkish language file for cState
-# Version 3.0
+# Version 6.0
 
 - id: languageCode
   translation: tr
@@ -114,7 +114,7 @@
 - id: notFoundText
   translation: Belki de aradığınız şeyi başka bir yere taşımışızdır. O şey hiç bulunmamış da olabilir. İki defa dene belki işe yarar?
 
-- id: rss
+- id: subscribeViaRss
   translation: RSS beslemesine abone ol
 - id: toAllUpdates
   translation: bütün güncellemelere
@@ -131,9 +131,99 @@
 - id: newestToOldest
   translation: en yeniden en eskiye
 
-# TODO: Missing translations from v3 to v6
+##
+## v4
+##
+- id: notFoundAffected
+  translation: Bu sistem ya mevcut değil ya da hiç kaydedilmiş bir kesinti yaşamadı.
 
+##
+## v4.1
+##
+
+- id: averageSystemsDowntime
+	translation: Son zamanlarda, ortalama verilere göre, bu sistem yaklaşık olarak
+- id: averageSystemsDowntimeSecondPart
+	translation: dakika boyunca çalışmıyor gibi görünüyor.
+
+##
+## v4.4
+##
+
+- id: in
+  translation: içinde
+- id: weeksAgo
+  translation: " hf"
+- id: yearAgo
+  translation: " yıl"
+
+##
 ## v6
 ##
+
 - id: incidentMaxAgeNotice
-  translation: "Hindi ipinapakita ang mga insidente na higit sa {{ .MaxAgeYears }} taon"
+  translation: "{{ .MaxAgeYears }} yıldan daha eski olaylar gösterilmiyor"
+- id: loading
+  translation: "Yükleniyor"
+- id: chart
+  translation: "Grafik"
+- id: getSupport
+  translation: "Destek alın"
+- id: subscribe
+  translation: "Abone Ol"
+- id: subscribeDescription
+  translation: "Bu durum sayfasından güncellemeler almak için abone olun."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "E-posta"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "Webhook URL'si"
+- id: embed
+  translation: "Göm"
+- id: embedDescription
+  translation: "Bu durum sayfasını kendi web sitenize veya uygulamanıza gömebilirsiniz. Herhangi bir aksaklık durumunda açılır bir mesaj almak için aşağıdaki HTML kod parçacığını kopyalayıp yapıştırmanız yeterlidir:"
+- id: copy
+  translation: "Kopyala"
+- id: embedDisclaimer
+  translation: "Bu gömme hakkında daha fazla bilgi ve nasıl kullanabileceğiniz hakkında bilgi mi arıyorsunuz?"
+- id: learnMore
+  translation: "Buradan daha fazla bilgi edinin"
+- id: pushNotifications
+  translation: "Push Bildirimleri"
+- id: pushNotificationsDescription
+  translation: "Tarayıcınız aracılığıyla push bildirimleri yoluyla bu durum sayfasına abone olabilirsiniz. Bildirim almak istediğiniz her cihazda bunu yapmanız gerekecektir. Bu özelliğin tarayıcı desteğine tabi olduğunu ve beklendiği gibi tüm cihazlarda çalışmayabileceğini lütfen unutmayın."
+- id: pushNotificationsDisclaimer
+  translation: "Kritik güncellemelerin mümkün olan en kısa sürede teslim edilmesini istiyorsanız, farklı bir bildirim yöntemi seçmenizi öneririz."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Bu durum sayfasındaki bilgileri ve güncellemeleri kendi web sitenize veya uygulamanıza entegre etmek için API'mizi kullanabilirsiniz. Aşağıdaki URL'ye bir GET isteği yapmanız yeterlidir:"
+- id: APIdisclaimer
+  translation: "Lütfen API'nin hız sınırlamasına tabi olabileceğini unutmayın."
+- id: getAllUpdates
+  translation: "Tüm güncellemeleri al"
+- id: getSomeUpdates
+  translation: "Yalnızca bazı sistemlerden güncelleme al"
+- id: openDropdown
+  translation: "Açılır menüyü aç"
+- id: closeDropdown
+  translation: "Açılır menüyü kapat"
+- id: automated
+  translation: "Otomatik"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Bu gönderi otomatik olarak oluşturuldu."
+- id: readDocumentation
+  translation: "Belgeleri oku"
+- id: copied
+  translation: "Kopyalandı!"
+- id: copyToClipboard
+  translation: "Panoya kopyala"
+- id: open
+  translation: "Aç"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -130,3 +130,10 @@
   translation: girdiler
 - id: newestToOldest
   translation: en yeniden en eskiye
+
+# TODO: Missing translations from v3 to v6
+
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "Hindi ipinapakita ang mga insidente na higit sa {{ .MaxAgeYears }} taon"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -1,5 +1,5 @@
 # Ukrainian language file for cState
-# Version 4.4
+# Version 6.0
 
 - id: languageCode
   translation: uk
@@ -113,7 +113,7 @@
 - id: notFoundText
   translation: Це може бути проблемою з нашого боку. Можливо, ми перемістили певний ресурс і тепер його немає. Також можливо, що ресурс, який ви намагаєтеся переглянути, порожній. Але ви також не проти ще раз перевірити посилання?
 
-- id: rss
+- id: subscribeViaRss
   translation: Підпишіться через RSS
 - id: toAllUpdates
   translation: на всі оновлення
@@ -160,3 +160,67 @@
 ##
 - id: incidentMaxAgeNotice
   translation: "Не показувати інциденти, яким більше {{ .MaxAgeYears }} років"
+- id: loading
+  translation: "Завантаження"
+- id: chart
+  translation: "Діаграма"
+- id: getSupport
+  translation: "Отримати підтримку"
+- id: subscribe
+  translation: "Підписатися"
+- id: subscribeDescription
+  translation: "Підпишіться на оновлення з цієї сторінки стану."
+- id: rss
+  translation: "RSS"
+- id: email
+  translation: "Електронна пошта"
+- id: discord
+  translation: "Discord"
+- id: slack
+  translation: "Slack"
+- id: webhook
+  translation: "Webhook"
+- id: webhookUrl
+  translation: "URL-адреса вебхука"
+- id: embed
+  translation: "Вставити"
+- id: embedDescription
+  translation: "Ви можете вставити цю сторінку стану на свій власний веб-сайт або в додаток. Просто скопіюйте наступний фрагмент HTML і вставте його, щоб отримати спливаюче повідомлення, якщо є збої:"
+- id: copy
+  translation: "Копіювати"
+- id: embedDisclaimer
+  translation: "Шукаєте більше інформації про це вбудовування та як його можна використовувати?"
+- id: learnMore
+  translation: "Дізнайтеся більше тут"
+- id: pushNotifications
+  translation: "Push-сповіщення"
+- id: pushNotificationsDescription
+  translation: "Ви можете підписатися на цю сторінку стану за допомогою push-сповіщень через свій браузер. Вам потрібно буде зробити це на кожному пристрої, на якому ви хочете отримувати сповіщення. Зверніть увагу, що ця функція залежить від підтримки браузера і може працювати не на всіх пристроях належним чином."
+- id: pushNotificationsDisclaimer
+  translation: "Ми рекомендуємо вибрати інший спосіб сповіщення, якщо вам потрібно, щоб критичні оновлення доставлялися якомога швидше."
+- id: API
+  translation: "API"
+- id: APIdescription
+  translation: "Ви можете використовувати наш API, щоб інтегрувати інформацію та оновлення з цієї сторінки стану у свій власний веб-сайт або додаток. Просто зробіть GET-запит за такою URL-адресою:"
+- id: APIdisclaimer
+  translation: "Зверніть увагу, що API може підлягати обмеженню швидкості."
+- id: getAllUpdates
+  translation: "Отримати всі оновлення"
+- id: getSomeUpdates
+  translation: "Отримувати оновлення лише від деяких систем"
+- id: openDropdown
+  translation: "Відкрити спадне меню"
+- id: closeDropdown
+  translation: "Закрити спадне меню"
+- id: automated
+  translation: "Автоматично"
+- id: thisPostWasAutomaticallyGenerated
+  translation: "Це повідомлення було згенеровано автоматично."
+- id: readDocumentation
+  translation: "Читати документацію"
+- id: copied
+  translation: "Скопійовано!"
+- id: copyToClipboard
+  translation: "Копіювати в буфер обміну"
+- id: open
+  translation: "Відкрити"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -155,3 +155,8 @@
   translation: ' тиж.'
 - id: yearAgo
   translation: ' р.'
+
+## v6
+##
+- id: incidentMaxAgeNotice
+  translation: "Не показувати інциденти, яким більше {{ .MaxAgeYears }} років"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,28 +1,135 @@
 {{ partial "meta" . }}
+{{ $title := .Title }}
 
-{{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
-{{ $active := where $incidents "Params.resolved" "=" false }}
+<body class="default list">
+	<header>
+		<div class="contain">
+			<a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
+			<div class="padding"></div>
+			<div class="padding"></div>
 
-{{ $isNotice := where $active "Params.severity" "=" "notice" }}
-{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
-{{ $isDown := where $active "Params.severity" "=" "down" }}
+			<!-- Hugo's Title (Fallback if JS is disabled) -->
+			<h1 class="clean" id="component-title">404 - {{ T "notFound" }}</h1>
 
-  <body class="status-homepage status-{{ if $isDown }}down{{ else }}{{ if $isDisrupted}}disrupted{{ else }}{{ if $isNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }} {{ if not .Site.Params.alwaysKeepBrandColor }}change-header-color{{ end }}">
-    {{ partial "header" . }}
+			<div class="padding"></div>
 
-    <div class="contain center">
-      <h1 class="bold">{{ T "notFound" }}</h1>
-      <p class="affected-text hidden">{{ T "notFoundAffected" }}</p>
-      <p>{{ T "notFoundText" }}</p>
-    </div>
-    
-    <script>
-      if (window.location.pathname.includes('affected')) {
-        document.querySelector('.affected-text').className = "affected-text";
-      }
-    </script>
+			<!-- Status Marker Start -->
+			<div id="status-marker"></div>
+			<!-- Status Marker End -->
 
-    {{ partial "js" . }}
-    {{ partial "footer" . }}
-  </body>
+			<!-- Description placeholder -->
+			<div id="component-description" class="faded"></div>
+
+			<div class="padding"></div>
+			<div class="padding"></div>
+			<div class="padding"></div>
+			<div class="padding"></div>
+			<div class="padding"></div>
+
+
+			{{ if .Site.Params.enableLastMod }}
+			<div class="contain center">
+				<small>{{ T "lastChecked" }}:
+					{{ if .Site.Params.dateFormat }}
+					{{ dateFormat .Site.Params.dateFormat now }}
+					{{ else }}
+					{{ now.Format "January 2, 2006 at 3:04 PM" }}
+					{{ end }}
+				</small>
+				<div class="padding"></div>
+			</div>
+			{{ end }}
+		</div>
+	</header>
+
+	<!-- No incident listing here. Just a static page. -->
+
+	<script>
+		// Bring in your cState color config
+		const colorOk = "{{ .Site.Params.ok }}";
+		const colorDown = "{{ .Site.Params.down }}";
+		const colorDisrupted = "{{ .Site.Params.disrupted }}";
+		const colorMaintenance = "{{ .Site.Params.notice }}";
+
+		// Bring in text translations
+		const txtOk = "{{ T "thisIsOk" }}";
+		const txtDown = "{{ T "thisIsDown" }}";
+		const txtDisrupted = "{{ T "thisIsDisrupted" }}";
+		const txtMaintenance = "{{ T "thisIsMaintenance" }}";
+
+		// Symbols or icons
+		const symOk = "◆";
+		const symDown = "■";
+		const symDisrupted = "▲";
+		const symMaintenance = "◆";
+
+		// Helper to slugify system names (to compare with path)
+		function slugify(name) {
+			return name.toLowerCase()
+				.replace(/[^a-z0-9]+/g, '-')
+				.replace(/^-+|-+$/g, '');
+		}
+
+		// Derive the system slug from the URL path.
+		// e.g. /affected/backup-gateway/ => systemSlug = "backup-gateway"
+		const pathParts = window.location.pathname.split('/');
+		let systemSlug = pathParts[pathParts.length - 2];
+		// If your route is /affected/backup-gateway without a trailing slash,
+		// adjust the index logic or ensure trailing slash is forced.
+
+		// Provide fallback 404 UI
+		function show404() {
+			document.getElementById("component-title").textContent = "404 - {{ T "notFound" }}";
+			document.getElementById("component-description").textContent =
+				"{{ T "notFoundText" }}";
+			document.getElementById("status-marker").innerHTML = "";
+		}
+
+		// Fetch index.json and compare
+		fetch("/index.json", { cache: "no-cache" })
+			.then(resp => {
+				if (!resp.ok) throw new Error(resp.statusText);
+				return resp.json();
+			})
+			.then(data => {
+				// Attempt to find a system whose slug matches systemSlug
+				const found = data.systems.find(sys => slugify(sys.name) === systemSlug);
+				if (!found) {
+					show404();
+					return;
+				}
+
+				// Found a system: Update the page
+				document.getElementById("component-title").textContent = found.name;
+				if (found.description) {
+					document.getElementById("component-description").innerHTML = found.description;
+				}
+
+				// Now set status
+				const marker = document.getElementById("status-marker");
+				switch (found.status) {
+					case "down":
+						marker.innerHTML = `<strong style="color: ${colorDown}">${symDown} ${txtDown}</strong>`;
+						break;
+					case "disrupted":
+						marker.innerHTML = `<strong style="color: ${colorDisrupted}">${symDisrupted} ${txtDisrupted}</strong>`;
+						break;
+					case "notice":
+						marker.innerHTML = `<strong style="color: ${colorMaintenance}">${symMaintenance} ${txtMaintenance}</strong>`;
+						break;
+					default:
+						marker.innerHTML = `<strong style="color: ${colorOk}">${symOk} ${txtOk}</strong>`;
+						break;
+				}
+			})
+			.catch(err => {
+				// If fetching or parsing fails, revert to 404 UI
+				show404();
+			});
+	</script>
+
+	{{ partial "js" . }}
+	{{ partial "footer" . }}
+</body>
+
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,117 +1,37 @@
 {{ partial "meta" . }}
 {{ $title := .Title }}
 
-  <body class="default list">
-    <header>
-      <div class="contain">
-        <a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
-        <div class="padding"></div>
-        <div class="padding"></div>
+<body class="default list">
+	<header>
+		<div class="contain center">
+			<a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
+			<div class="padding"></div><div class="padding"></div>
 
-        <h1 class="clean">{{ $title }}</h1>
+			<h1 class="clean">
+				{{ if eq $title "Issues" }}
+					{{ T "incidentHistory" }}
+				{{ else }}
+					{{ $title }}
+				{{ end }}
+			</h1>
 
-        {{ range .Site.Params.systems }}
-          {{ if eq .name $title }}
-            {{ with .description }}
-              <p class="bold">{{ . }}</p>
-            {{ end }}
-          {{ end }}
-        {{ end }}
- 
+		</div>
+	</header>
 
-        
-        <!-- Average downtime -->
-        {{ if not .Site.Params.disableComplexCalculations }}
-        <p class="bold">
-          <em>
-            {{ $resolved := first 5 (where .Pages "Params.resolved" "=" true) }}
-
-            {{ if gt $resolved 0 }}
-              {{ $.Scratch.Set "counter" 0 }}
-              {{ range $resolved }}
-
-              {{ $t := (time .Params.ResolvedWhen) }}
-                {{ $timeDiff := (sub $t.Unix .Date.Unix) }}
-                {{ $diffInMin := (div $timeDiff 60) }}
-
-                {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") $diffInMin) }}
-              {{ end }}
-
-              {{ T "averageSystemsDowntime" }}
-              
-              {{ div ($.Scratch.Get "counter") (len $resolved) }}
-              {{ T "averageSystemsDowntimeSecondPart" }}
-            {{ end }}
-          </em>
-        </p>
-        {{ end }}
+	{{ if not .Site.Params.disableIncidentHistory }}
+	<div class="contain contain--more" id="incidents">
+		{{  if eq .Site.Params.incidentHistoryFormat "monthly" }}
+		{{ partial "index/incidents-monthly" . }}
+		{{ else }}
+		{{ partial "index/incidents-yearly" . }}
+		{{ end }}
+		<div class="padding"></div>
+	</div>
+	{{ end }}
 
 
-        <small class="faded">{{ len .Pages }} {{ T "entries" }}, {{ T "newestToOldest" }}</small>
+	{{ partial "js" . }}
+	{{ partial "footer" . }}
+</body>
 
-        <div class="padding"></div>
-        <hr class="clean">
-      </div>
-      {{ $incidents := .Pages }}
-    </header>
-
-    <div class="contain contain--more" id="incidents">
-      {{ if not $incidents }}
-        <div class="padding"></div>
-        <h3>{{ T "calmBeforeTheStorm" }}</h3>
-        <p>{{ T "noIncidentsDesc" }}</p>
-        <div class="padding"></div>
-        <div class="padding"></div>
-        <div class="padding"></div>
-      {{ else }}
-        {{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
-        {{ range $paginator.Pages }}
-          {{ .Render "small" }}
-        {{ end }}
-
-        <!-- If there are more than 2 pages, show pagination -->
-        {{ if gt $paginator.TotalPages 1 }}
-          <hr>
-
-          <div class="center">
-            {{ if $paginator.HasPrev }}
-              <a href="{{ $paginator.Prev.URL }}#incidents">
-                ← &nbsp;
-                {{ T "prev" }}
-              </a>
-            {{ else }}
-              <span class="faded">
-                ← &nbsp;
-                {{ T "prev" }}
-              </span>
-            {{ end }}
-
-
-            &nbsp; &nbsp;
-            {{ $paginator.PageNumber }}
-            /
-            {{ $paginator.TotalPages }}
-            &nbsp; &nbsp;
-
-
-            {{ if $paginator.HasNext }}
-              <a href="{{ $paginator.Next.URL }}#incidents">
-                {{ T "next" }} &nbsp;
-                →
-              </a>
-            {{ else }}
-              <span class="faded">
-                {{ T "next" }} &nbsp;
-                →
-              </span>
-            {{ end }}
-          </div>
-        {{ end }}
-      {{ end }}
-      <div class="padding"></div>
-    </div>
-
-    {{ partial "js" . }}
-    {{ partial "footer" . }}
-  </body>
 </html>

--- a/layouts/affected/list.html
+++ b/layouts/affected/list.html
@@ -1,0 +1,117 @@
+{{ partial "meta" . }}
+{{ $title := .Title }}
+
+  <body class="default list">
+    <header>
+      <div class="contain">
+        <a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
+        <div class="padding"></div>
+        <div class="padding"></div>
+
+        <h1 class="clean">{{ $title }}</h1>
+
+        {{ range .Site.Params.systems }}
+          {{ if eq .name $title }}
+            {{ with .description }}
+              <p class="bold">{{ . }}</p>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+ 
+
+        
+        <!-- Average downtime -->
+        {{ if not .Site.Params.disableComplexCalculations }}
+        <p class="bold">
+          <em>
+            {{ $resolved := first 5 (where .Pages "Params.resolved" "=" true) }}
+
+            {{ if gt $resolved 0 }}
+              {{ $.Scratch.Set "counter" 0 }}
+              {{ range $resolved }}
+
+              {{ $t := (time .Params.ResolvedWhen) }}
+                {{ $timeDiff := (sub $t.Unix .Date.Unix) }}
+                {{ $diffInMin := (div $timeDiff 60) }}
+
+                {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") $diffInMin) }}
+              {{ end }}
+
+              {{ T "averageSystemsDowntime" }}
+              
+              {{ div ($.Scratch.Get "counter") (len $resolved) }}
+              {{ T "averageSystemsDowntimeSecondPart" }}
+            {{ end }}
+          </em>
+        </p>
+        {{ end }}
+
+
+        <small class="faded">{{ len .Pages }} {{ T "entries" }}, {{ T "newestToOldest" }}</small>
+
+        <div class="padding"></div>
+        <hr class="clean">
+      </div>
+      {{ $incidents := .Pages }}
+    </header>
+
+    <div class="contain contain--more" id="incidents">
+      {{ if not $incidents }}
+        <div class="padding"></div>
+        <h3>{{ T "calmBeforeTheStorm" }}</h3>
+        <p>{{ T "noIncidentsDesc" }}</p>
+        <div class="padding"></div>
+        <div class="padding"></div>
+        <div class="padding"></div>
+      {{ else }}
+        {{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
+        {{ range $paginator.Pages }}
+          {{ .Render "small" }}
+        {{ end }}
+
+        <!-- If there are more than 2 pages, show pagination -->
+        {{ if gt $paginator.TotalPages 1 }}
+          <hr>
+
+          <div class="center">
+            {{ if $paginator.HasPrev }}
+              <a href="{{ $paginator.Prev.URL }}#incidents">
+                ← &nbsp;
+                {{ T "prev" }}
+              </a>
+            {{ else }}
+              <span class="faded">
+                ← &nbsp;
+                {{ T "prev" }}
+              </span>
+            {{ end }}
+
+
+            &nbsp; &nbsp;
+            {{ $paginator.PageNumber }}
+            /
+            {{ $paginator.TotalPages }}
+            &nbsp; &nbsp;
+
+
+            {{ if $paginator.HasNext }}
+              <a href="{{ $paginator.Next.URL }}#incidents">
+                {{ T "next" }} &nbsp;
+                →
+              </a>
+            {{ else }}
+              <span class="faded">
+                {{ T "next" }} &nbsp;
+                →
+              </span>
+            {{ end }}
+          </div>
+        {{ end }}
+      {{ end }}
+      <div class="padding"></div>
+    </div>
+
+    {{ partial "js" . }}
+    {{ partial "footer" . }}
+  </body>
+</html>

--- a/layouts/affected/list.html
+++ b/layouts/affected/list.html
@@ -1,117 +1,131 @@
 {{ partial "meta" . }}
 {{ $title := .Title }}
 
-  <body class="default list">
-    <header>
-      <div class="contain">
-        <a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
-        <div class="padding"></div>
-        <div class="padding"></div>
+<body class="default list">
+	<header>
+		<div class="contain">
+			<a href="{{ .Site.BaseURL }}">← {{ T "goBack" }} <em>{{ .Site.Title }}</em></a>
+			<div class="padding"></div>
+			<div class="padding"></div>
 
-        <h1 class="clean">{{ $title }}</h1>
+			<h1 class="clean">{{ $title }}</h1>
 
-        {{ range .Site.Params.systems }}
-          {{ if eq .name $title }}
-            {{ with .description }}
-              <p class="bold">{{ . }}</p>
-            {{ end }}
-          {{ end }}
-        {{ end }}
- 
+			<!-- Status Marker Start -->
+			<div class="padding-s"></div>
+			{{/* Collect all unresolved incidents for this component */}}
+			{{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
+			{{ $active := where $incidents "Params.resolved" "=" false }}
+			{{ $componentIssues := where $active "Params.affected" "intersect" (slice $title) }}
 
-        
-        <!-- Average downtime -->
-        {{ if not .Site.Params.disableComplexCalculations }}
-        <p class="bold">
-          <em>
-            {{ $resolved := first 5 (where .Pages "Params.resolved" "=" true) }}
+			{{ $isDown := where $componentIssues "Params.severity" "=" "down" }}
+			{{ $isDisrupted := where $componentIssues "Params.severity" "=" "disrupted" }}
+			{{ $isMaintenance := where $componentIssues "Params.severity" "=" "notice" }}
 
-            {{ if gt $resolved 0 }}
-              {{ $.Scratch.Set "counter" 0 }}
-              {{ range $resolved }}
+			{{ if gt (len $isDown) 0 }}
+			<strong style="color: {{ .Site.Params.down }}">■ {{ T "thisIsDown" }}</strong>
+			{{ else if gt (len $isDisrupted) 0 }}
+			<strong style="color: {{ .Site.Params.disrupted }}">▲ {{ T "thisIsDisrupted" }}</strong>
+			{{ else if gt (len $isMaintenance) 0 }}
+			<strong style="color: {{ .Site.Params.notice }}">◆ {{ T "thisIsMaintenance" }}</strong>
+			{{ else }}
+			<strong style="color: {{ .Site.Params.ok }}">◆ {{ T "thisIsOk" }}</strong>
+			{{ end }}
+			<div class="padding-s"></div>
+			<!-- Status Marker End -->
 
-              {{ $t := (time .Params.ResolvedWhen) }}
-                {{ $timeDiff := (sub $t.Unix .Date.Unix) }}
-                {{ $diffInMin := (div $timeDiff 60) }}
+			{{ range .Site.Params.systems }}
+			{{ if eq .name $title }}
+			{{ with .description }}
+			{{ . | markdownify }}
+			{{ end }}
+			{{ end }}
+			{{ end }}
 
-                {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") $diffInMin) }}
-              {{ end }}
+			{{ if .Content }}
+			<div class="padding"></div>
+			<div class="archive__head">
+				{{ .Content }}
+			</div>
+			<div class="padding"></div>
+			{{ end }}
 
-              {{ T "averageSystemsDowntime" }}
-              
-              {{ div ($.Scratch.Get "counter") (len $resolved) }}
-              {{ T "averageSystemsDowntimeSecondPart" }}
-            {{ end }}
-          </em>
-        </p>
-        {{ end }}
+			{{ if not .Site.Params.disableComplexCalculations }}
+			<p class="bold">
+				<em>
+					{{ $resolved := first 5 (where .Pages "Params.resolved" "=" true) }}
+					{{ if gt $resolved 0 }}
+					{{ $.Scratch.Set "counter" 0 }}
+					{{ range $resolved }}
+					{{ $t := (time .Params.ResolvedWhen) }}
+					{{ $timeDiff := (sub $t.Unix .Date.Unix) }}
+					{{ $diffInMin := (div $timeDiff 60) }}
+					{{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") $diffInMin) }}
+					{{ end }}
 
+					{{ T "averageSystemsDowntime" }}
+					{{ div ($.Scratch.Get "counter") (len $resolved) }}
+					{{ T "averageSystemsDowntimeSecondPart" }}
+					{{ end }}
+				</em>
+			</p>
+			{{ end }}
 
-        <small class="faded">{{ len .Pages }} {{ T "entries" }}, {{ T "newestToOldest" }}</small>
+			<small class="faded">{{ len .Pages }} {{ T "entries" }}, {{ T "newestToOldest" }}</small>
 
-        <div class="padding"></div>
-        <hr class="clean">
-      </div>
-      {{ $incidents := .Pages }}
-    </header>
+			<div class="padding"></div>
+			<hr class="clean">
+		</div>
+		{{ $incidents := .Pages }}
+	</header>
 
-    <div class="contain contain--more" id="incidents">
-      {{ if not $incidents }}
-        <div class="padding"></div>
-        <h3>{{ T "calmBeforeTheStorm" }}</h3>
-        <p>{{ T "noIncidentsDesc" }}</p>
-        <div class="padding"></div>
-        <div class="padding"></div>
-        <div class="padding"></div>
-      {{ else }}
-        {{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
-        {{ range $paginator.Pages }}
-          {{ .Render "small" }}
-        {{ end }}
+	<div class="contain contain--more" id="incidents">
+		{{ if not $incidents }}
+		<div class="padding"></div>
+		<h3>{{ T "calmBeforeTheStorm" }}</h3>
+		<p>{{ T "noIncidentsDesc" }}</p>
+		<div class="padding"></div>
+		<div class="padding"></div>
+		<div class="padding"></div>
+		{{ else }}
+		{{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
+		{{ range $paginator.Pages }}
+		{{ .Render "small" }}
+		{{ end }}
 
-        <!-- If there are more than 2 pages, show pagination -->
-        {{ if gt $paginator.TotalPages 1 }}
-          <hr>
+		{{ if gt $paginator.TotalPages 1 }}
+		<hr>
+		<div class="center">
+			{{ if $paginator.HasPrev }}
+			<a href="{{ $paginator.Prev.URL }}#incidents">
+				← &nbsp; {{ T "prev" }}
+			</a>
+			{{ else }}
+			<span class="faded">
+				← &nbsp; {{ T "prev" }}
+			</span>
+			{{ end }}
 
-          <div class="center">
-            {{ if $paginator.HasPrev }}
-              <a href="{{ $paginator.Prev.URL }}#incidents">
-                ← &nbsp;
-                {{ T "prev" }}
-              </a>
-            {{ else }}
-              <span class="faded">
-                ← &nbsp;
-                {{ T "prev" }}
-              </span>
-            {{ end }}
+			&nbsp; &nbsp;
+			{{ $paginator.PageNumber }} / {{ $paginator.TotalPages }}
+			&nbsp; &nbsp;
 
+			{{ if $paginator.HasNext }}
+			<a href="{{ $paginator.Next.URL }}#incidents">
+				{{ T "next" }} &nbsp; →
+			</a>
+			{{ else }}
+			<span class="faded">
+				{{ T "next" }} &nbsp; →
+			</span>
+			{{ end }}
+		</div>
+		{{ end }}
+		{{ end }}
+		<div class="padding"></div>
+	</div>
 
-            &nbsp; &nbsp;
-            {{ $paginator.PageNumber }}
-            /
-            {{ $paginator.TotalPages }}
-            &nbsp; &nbsp;
+	{{ partial "js" . }}
+	{{ partial "footer" . }}
+</body>
 
-
-            {{ if $paginator.HasNext }}
-              <a href="{{ $paginator.Next.URL }}#incidents">
-                {{ T "next" }} &nbsp;
-                →
-              </a>
-            {{ else }}
-              <span class="faded">
-                {{ T "next" }} &nbsp;
-                →
-              </span>
-            {{ end }}
-          </div>
-        {{ end }}
-      {{ end }}
-      <div class="padding"></div>
-    </div>
-
-    {{ partial "js" . }}
-    {{ partial "footer" . }}
-  </body>
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,13 +39,7 @@
   <!-- All incidents + pagination -->
   {{ if not .Site.Params.disableIncidentHistory }}
     <div class="contain contain--more" id="incidents">
-      {{ if eq .Site.Params.incidentHistoryFormat "yearly" }}
-        {{ partial "index/incidents-yearly" . }}
-      {{ else if eq .Site.Params.incidentHistoryFormat "monthly" }}
-        {{ partial "index/incidents-monthly" . }}
-      {{ else }}
-        {{ partial "index/incidents" . }}
-      {{ end }}
+	  {{ partial "index/incidents" . }}
       <div class="padding"></div>
     </div>
   {{ end }}

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,13 +1,13 @@
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}{{ $active := where $incidents "Params.resolved" "=" false }}{{ $isNotice := where $active "Params.severity" "=" "notice" }}{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}{{ $isDown := where $active "Params.severity" "=" "down" }}{
   "is": "index",
-  "cStateVersion": "5.6.1",
+  "cStateVersion": "6.0",
   "apiVersion": "2.0",
   "title": "{{ .Site.Title }}",
   "languageCodeHTML": "{{ .Site.LanguageCode }}",
   "languageCode": "{{ T "languageCode" }}",
-  "baseURL": "{{ .Site.BaseURL }}", 
+  "baseURL": "{{ .Site.BaseURL }}",
   "description": "{{ .Site.Params.Description }}",
-  "summaryStatus": {{ if $isDown }}"down",{{ else }}{{ if $isDisrupted }}"disrupted",{{ else }}{{ if $isNotice }}"notice",{{ else }}"ok",{{ end }}{{ end }}{{ end }} 
+  "summaryStatus": {{ if $isDown }}"down",{{ else }}{{ if $isDisrupted }}"disrupted",{{ else }}{{ if $isNotice }}"notice",{{ else }}"ok",{{ end }}{{ end }}{{ end }}
   "categories": [{{ range $i, $e := .Site.Params.categories }}{{ if $i }},{{ end }}
       {
         "name": "{{ .name }}",{{ if .description }}
@@ -36,7 +36,7 @@
       {
         "name": "{{ .name }}",{{ if .description }}
         "description": "{{ .description }}",{{ end }}
-        "category": "{{ .category }}", 
+        "category": "{{ .category }}",
         {{ $activeComponentIssues := where $active "Params.affected" "intersect" (slice .name) }}{{ $thisIsNotice := where $activeComponentIssues "Params.severity" "=" "notice" }}{{ $thisIsDisrupted := where $activeComponentIssues "Params.severity" "=" "disrupted" }}{{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
         "status": {{ if $thisIsDown }}"down"{{ else }}{{ if $thisIsDisrupted }}"disrupted"{{ else }}{{ if $thisIsNotice }}"notice"{{ else }}"ok"{{ end }}{{ end }}{{ end }},
         {{ if not $activeComponentIssues }}
@@ -63,12 +63,12 @@
   {{ if .Site.Params.customTabs }}
   "tabs": [{{ range $i, $e := .Site.Params.customTabs }}{{ if $i }},{{ end }}
       {
-        "name": "{{ .name }}", 
+        "name": "{{ .name }}",
         "link": "{{ .description }}"
       }
     {{ end }}
   ],{{ end }}
-  
+
   "buildDate": "{{ now.Format "2006-01-02" }}",
   "buildTime": "{{ now.Format "15:04" }}",
   "buildTimezone": "{{ now.Format "MST" }}",

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -20,7 +20,7 @@
 
 	<p><small>
 			{{ range .Params.Affected }}
-			<a href="{{ printf " affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+			<a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
 			{{ end }}
 		</small></p>
 

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -6,97 +6,73 @@
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
 <div class="article">
-  <h1 class="clean">
-    {{ .Title }}
-  </h1>
+	<h1 class="clean">
+		{{ .Title }}
+	</h1>
 
-  <small class="date">
-    {{ if .Site.Params.dateFormat }}
-      {{ dateFormat .Site.Params.dateFormat .Params.date }}
-    {{ else }}
-      {{ .Date.Format "January 2, 2006 at 3:04 PM" }}
-    {{ end }}
-  </small>
+	<small class="date">
+		{{ if .Site.Params.dateFormat }}
+		{{ dateFormat .Site.Params.dateFormat .Params.date }}
+		{{ else }}
+		{{ .Date.Format "January 2, 2006 at 3:04 PM" }}
+		{{ end }}
+	</small>
 
-  <p><small>
-    {{ range .Params.Affected }}
-      <a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
-    {{ end }}
-  </small></p>
+	<p><small>
+			{{ range .Params.Affected }}
+			<a href="{{ printf " affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
+			{{ end }}
+		</small></p>
 
-  {{ if .Params.informational }}
-  {{ else if .Params.Resolved }}
-  {{ $t := (time .Params.ResolvedWhen) }}
-  {{ $timeDiff := (sub $t.Unix .Date.Unix) }}
-  {{ $diffInMin := (div $timeDiff 60) }}
+	{{ if .Params.informational }}
+	{{ else if .Params.Resolved }}
+	{{ $resolvedTime := (time .Params.ResolvedWhen) }}
+	{{ $timeDiff := (sub $resolvedTime.Unix .Date.Unix) }}
+	{{ $diffInMin := (div $timeDiff 60) }}
+	{{ $days := div $timeDiff 86400 }}
+	{{ $remainingSeconds := mod $timeDiff 86400 }}
+	{{ $hours := div $remainingSeconds 3600 }}
+	{{ $minutes := div (mod $remainingSeconds 3600) 60 }}
 
+	<!-- Marker -->
+	<div
+		class="{{ if lt $timeDiff 60 }}faded{{ else if gt $days 0 }}warning{{ else if gt $hours 0 }}warning{{ else }}ok{{ end }}">
+		{{ if lt $timeDiff 60 }}
+		<strong>{{ T "resolved" }} {{ T "inUnderAMinute" }}</strong>
+		{{ else }}
+		<strong>
+			{{ T "resolvedAfter" }}
+			{{ if gt $days 0 }}{{ $days }}d {{ end }}
+			{{ if gt $hours 0 }}{{ $hours }}h {{ end }}
+			{{ $minutes }}m
+			{{ if eq .Params.severity "down" }}
+			{{ T "ofDowntime" }}
+			{{ end }}
+		</strong>
+		<span class="tooltip__text">
+			{{ if .Site.Params.dateFormat }}
+			{{ dateFormat .Site.Params.dateFormat .Params.resolvedWhen }}
+			{{ else }}
+			{{ dateFormat "January 2, 2006 at 3:04 PM" .Params.resolvedWhen }}
+			{{ end }}
+		</span>
+		{{ end }}
+	</div>
+	{{ else }}
+	<strong>
+		{{ if eq .Params.severity "down" }}
+		<span style="color: {{ .Site.Params.down }}">■ {{ T "thisIsDown" }}</span>
+		{{ else if eq .Params.severity "disrupted" }}
+		<span style="color: {{ .Site.Params.disrupted }}">▲ {{ T "thisIsDisrupted" }}</span>
+		{{ else }}
+		<span style="color: {{ .Site.Params.notice }}">◆ {{ T "thisIsNotice" }}</span>
+		{{ end }}
+		<br />
+		{{ T "downtimeOngoing" }}
+	</strong>
+	{{ end }}
 
-  <!-- Marker -->
-  {{ if lt $timeDiff 60 }}
-  <div class="faded">
-    <strong>
-    {{ T "resolved" }} {{ T "inUnderAMinute" }}.
-    </strong>
-  </div>
-  {{ else }}
-    {{ if gt $timeDiff 3600 }}
-      <div class="warning tooltip">
-        <strong>
-          {{ T "resolvedAfter" }}
-
-          {{ $minutesForCalc := (mod $diffInMin 60) }}
-
-          {{ div (sub $diffInMin $minutesForCalc) 60 }}h
-          {{ $minutesForCalc }}m
-          {{ if eq .Params.severity "down" }}
-              {{ T "ofDowntime" }}
-          {{ end }}
-        </strong>
-
-        <span class="tooltip__text">
-          {{ if .Site.Params.dateFormat }}
-            {{ dateFormat .Site.Params.dateFormat .Params.resolvedWhen }}
-          {{ else }}
-            {{ dateFormat "January 2, 2006 at 3:04 PM" .Params.resolvedWhen }}
-          {{ end }}
-        </span>
-      </div>
-    {{ else }}
-      <div class="ok tooltip">
-        <strong>
-          {{ T "resolvedAfter" }}
-
-          {{ $secsForCalc := (mod $timeDiff 60) }}
-
-          {{ div (sub $timeDiff $secsForCalc) 60 }}m
-          {{ if eq .Params.severity "down" }}
-            {{ T "ofDowntime" }}
-          {{ end }}
-        </strong>
-
-        <span class="tooltip__text">
-          {{ if .Site.Params.dateFormat }}
-            {{ dateFormat .Site.Params.dateFormat .Params.resolvedWhen }}
-          {{ else }}
-            {{ dateFormat "January 2, 2006 at 3:04 PM" .Params.resolvedWhen }}
-          {{ end }}
-        </span>
-      </div>
-    {{ end }}
-  {{ end }}
-  {{ else }}
-    <strong class="error">
-      {{ if eq .Params.severity "down" }}
-      ■ 
-      {{ else if eq .Params.severity "disrupted" }}
-      ▲ 
-      {{ else }}
-      ◆ 
-      {{ end }}
-      {{ T "downtimeOngoing" }}</strong>
-  {{ end }}
-
-  <hr>
-  <div class="markdown">{{ .Content }}</div>
+	<hr>
+	<div class="markdown">{{ .Content }}</div>
 </div>
 <div class="padding"></div>

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -78,8 +78,8 @@
 
 
 
-	{{/* Only show the button if it's informational or a "notice" event */}}
-	{{ if or .Params.informational (eq .Params.severity "notice") }}
+	{{/* Add to Calendar */}}
+	{{ if eq .Params.severity "notice" }}
 
 	<div class="padding"></div>
 	<p><small class="faded"><b>Add this period to your calendar</b></small></p>

--- a/layouts/issues/issue.html
+++ b/layouts/issues/issue.html
@@ -18,6 +18,7 @@
 		{{ end }}
 	</small>
 
+
 	<p><small>
 			{{ range .Params.Affected }}
 			<a href="{{ printf "affected/%s/" (. | urlize) | relURL }}" class="tag no-underline">{{ . }}</a>
@@ -74,5 +75,88 @@
 
 	<hr>
 	<div class="markdown">{{ .Content }}</div>
+
+
+
+	{{/* Only show the button if it's informational or a "notice" event */}}
+	{{ if or .Params.informational (eq .Params.severity "notice") }}
+
+	<div class="padding"></div>
+	<p><small class="faded"><b>Add this period to your calendar</b></small></p>
+	<button id="addToCalendarBtn" class="tag" style="padding: 8px 12px">
+		Download event (.ics)
+	</button>
+
+	{{ $theTitle := .Title | default "Event" | plainify }}
+	{{ $theDescription := .Content | default "" | plainify | jsonify }}
+
+	<script>
+ 		const eventTitle = {{ $theTitle }};
+		const eventDescription = {{ $theDescription }};
+		const eventStart = "{{ .Date }}";           // from 'date' in front matter
+		const endDateRaw = "{{ .Params.resolvedWhen }}";
+		const eventLocation = "{{ .Site.BaseURL }}";   // or a more specific .Params.location if you have one
+
+		// If no resolvedWhen is defined, add 1 hour to the start date
+		let eventEnd = endDateRaw;
+		if (!endDateRaw || endDateRaw.trim() === "") {
+			const startTimeObj = new Date(eventStart);
+			startTimeObj.setHours(startTimeObj.getHours() + 1);
+			eventEnd = startTimeObj.toISOString();
+		}
+
+		function downloadICS() {
+			// Convert date strings into ICS-friendly format: YYYYMMDDTHHMMSSZ
+			function toICSDate(dString) {
+				const d = new Date(dString);
+				return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+			}
+
+			const dtStart = toICSDate(eventStart);
+			const dtEnd = toICSDate(eventEnd);
+
+			// ICS contents with a 1-hour reminder
+			const icsData = [
+				"BEGIN:VCALENDAR",
+				"VERSION:2.0",
+				"PRODID:-//cState//EN",
+				"BEGIN:VEVENT",
+				`UID:${Date.now()}@cstate`,
+				`DTSTAMP:${new Date().toISOString().replace(/[-:]/g, "").split(".")[0]}Z`,
+				`DTSTART:${dtStart}`,
+				`DTEND:${dtEnd}`,
+				// eventTitle and eventDescription are already safe strings (via jsonify)
+				`SUMMARY:${eventTitle}`,
+				`LOCATION:${eventLocation}`,
+				`DESCRIPTION:${eventDescription}`,
+				"BEGIN:VALARM",
+				"ACTION:DISPLAY",
+				"DESCRIPTION:Reminder",
+				"TRIGGER:-PT1H", // 1 hour beforehand
+				"END:VALARM",
+				"END:VEVENT",
+				"END:VCALENDAR"
+			].join("\r\n");
+
+			// Download as an .ics file
+			const blob = new Blob([icsData], { type: "text/calendar" });
+			const blobUrl = URL.createObjectURL(blob);
+
+			const link = document.createElement("a");
+			link.href = blobUrl;
+			link.download = eventTitle.replace(/[^\w\s-]/g, "") + ".ics";
+			// remove special chars from filename, or fallback to "event.ics" if empty
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+		}
+
+		document
+			.getElementById("addToCalendarBtn")
+			.addEventListener("click", downloadICS);
+	</script>
+
+	{{ end }}
+
 </div>
 <div class="padding"></div>

--- a/layouts/issues/single.html
+++ b/layouts/issues/single.html
@@ -20,10 +20,10 @@
     <div class="contain center">
       <small>{{ T "lastChecked" }}:
 
-        {{ if .Site.Params.dateFormat }}
+      {{ if .Site.Params.dateFormat }}
         {{ dateFormat .Site.Params.dateFormat .Lastmod }}
       {{ else }}
-        {{ .Lastmod.Format "January 2, 2006 at 3:04 PM" }}
+        {{ .Lastmod.Format "January 2, 2006 at 3:04 PM UTC" }}
       {{ end }}
 	  </small>
 	  <div class="padding"></div>

--- a/layouts/issues/single.html
+++ b/layouts/issues/single.html
@@ -13,24 +13,25 @@
     </div>
 
     <div class="contain">
-      {{ .Render "issue" }} 
+      {{ .Render "issue" }}
     </div>
-    
+
     {{ if .Site.Params.enableLastMod }}
     <div class="contain center">
-      <p>{{ T "lastChecked" }}:
+      <small>{{ T "lastChecked" }}:
 
         {{ if .Site.Params.dateFormat }}
         {{ dateFormat .Site.Params.dateFormat .Lastmod }}
       {{ else }}
         {{ .Lastmod.Format "January 2, 2006 at 3:04 PM" }}
       {{ end }}
-      </p>
+	  </small>
+	  <div class="padding"></div>
     </div>
     {{ end }}
 
 
-    
+
 
     {{ partial "js" . }}
     {{ partial "footer" . }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -8,7 +8,7 @@
 <a href="{{ .Permalink }}" class="issue no-underline">
   {{ if .Params.informational }}
 
-  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
+  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006" }}">
       {{ if .Site.Params.dateFormat }}
         {{ dateFormat .Site.Params.dateFormat .Params.date }}
       {{ else }}
@@ -21,7 +21,7 @@
     </h3>
 
   {{ else if .Params.Resolved }}
-    <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
+    <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006" }}">
       {{ if .Site.Params.dateFormat }}
         {{ dateFormat .Site.Params.dateFormat .Params.date }}
       {{ else }}
@@ -62,7 +62,7 @@
 
   {{ else }}
   <!-- If not resolved -->
-    <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
+    <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006" }}">
 
       {{ if .Date.Before now }}
         {{ if .Site.Params.dateFormat }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -95,17 +95,18 @@
         {{ end }}
       </strong>
     {{ else }}
-
-      <strong class="error">
-        {{ if eq .Params.severity "down" }}
-        ■
-        {{ else if eq .Params.severity "disrupted" }}
-        ▲
-        {{ else }}
-        ◆
-        {{ end }}
-        {{ T "downtimeOngoing" }}
-      </strong>
+		<strong>
+		{{ if eq .Params.severity "down" }}
+		<span style="color: {{ .Site.Params.down }}">■ {{ T "thisIsDown" }}</span>
+		{{ else if eq .Params.severity "disrupted" }}
+		<span style="color: {{ .Site.Params.disrupted }}">▲ {{ T "thisIsDisrupted" }}</span>
+		{{ else }}
+		<span style="color: {{ .Site.Params.notice }}">◆ {{ T "thisIsNotice" }}</span>
+		{{ end }}
+		</strong>
+		<span class="faded">
+			– {{ T "downtimeOngoing" }}
+		</span>
     {{ end }}
 
   {{ end }}

--- a/layouts/issues/small.html
+++ b/layouts/issues/small.html
@@ -19,11 +19,9 @@
     <h3>
       {{ .Title }} &nbsp;ℹ
     </h3>
-    <span class="faded">{{ .Summary | truncate 200 }}
-    </span>
 
   {{ else if .Params.Resolved }}
-  <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
+    <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
       {{ if .Site.Params.dateFormat }}
         {{ dateFormat .Site.Params.dateFormat .Params.date }}
       {{ else }}
@@ -40,41 +38,32 @@
     {{ $diffInMin := (div $timeDiff 60) }}
 
     <!-- Marker -->
-    {{ if lt $timeDiff 60 }}
-    <div class="faded">
-      {{ T "resolved" }} {{ T "inUnderAMinute" }}
-    </div>
-    {{ else }}
-      {{ if gt $timeDiff 3600 }}
-        <div class="warning">
-          {{ T "resolvedAfter" }}
+	{{ $t := (time .Params.ResolvedWhen) }}
+	{{ $timeDiff := (sub $t.Unix .Date.Unix) }}
+	{{ $days := div $timeDiff 86400 }}
+	{{ $remainingSeconds := mod $timeDiff 86400 }}
+	{{ $hours := div $remainingSeconds 3600 }}
+	{{ $minutes := div (mod $remainingSeconds 3600) 60 }}
 
-          {{ $minutesForCalc := (mod $diffInMin 60) }}
-
-          {{ div (sub $diffInMin $minutesForCalc) 60 }}h
-          {{ $minutesForCalc }}m
-          {{ if eq .Params.severity "down" }}
-            {{ T "ofDowntime" }}
-          {{ end }}
-        </div>
-      {{ else }}
-        <div class="ok">
-          {{ T "resolvedAfter" }}
-
-          {{ $secsForCalc := (mod $timeDiff 60) }}
-
-          {{ div (sub $timeDiff $secsForCalc) 60 }}m
-          {{ if eq .Params.severity "down" }}
-          <!-- {{ $secsForCalc }}s --> {{ T "ofDowntime" }}
-          {{ end }}
-        </div>
-      {{ end }}
-    {{ end }}
+	<div
+		class="{{ if lt $timeDiff 60 }}faded{{ else if gt $days 0 }}warning{{ else if gt $hours 0 }}warning{{ else }}ok{{ end }}">
+		{{ if lt $timeDiff 60 }}
+		{{ T "resolved" }}
+		{{ T "inUnderAMinute" }}
+		{{ else }}
+		{{ T "resolvedAfter" }} {{ if gt $days 0 }}{{ $days }}d {{ end }}
+		{{ if gt $hours 0 }}{{ $hours }}h {{ end }}
+		{{ $minutes }}m
+		{{ if eq .Params.severity "down" }}
+		{{ T "ofDowntime" }}
+		{{ end }}
+		{{ end }}
+	</div>
 
   {{ else }}
   <!-- If not resolved -->
     <small class="date float-right {{ cond .Site.Params.useRelativeTime "relative-time" "" }}" title="{{ dateFormat .Site.Params.dateFormat .Params.date }}" data-date="{{ .Date.Format "Jan 2 15:04:05 2006 UTC" }}">
-        
+
       {{ if .Date.Before now }}
         {{ if .Site.Params.dateFormat }}
           {{ dateFormat .Site.Params.dateFormat .Params.date }}
@@ -106,7 +95,7 @@
         {{ end }}
       </strong>
     {{ else }}
-    
+
       <strong class="error">
         {{ if eq .Params.severity "down" }}
         ■

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,11 +15,11 @@
 
     {{ if not .Site.Params.disableIncidentHistory }}
       <hr>
-      
+
       <p class="hinted">
         <small>
           ⚡
-          {{ T "rss" }} —
+          {{ T "subscribeViaRss" }} —
           {{ with $.Site.Home.OutputFormats.Get "rss" }}
             <a href="{{ .Permalink }}" class="no-underline">{{ T "toAllUpdates" }}</a>
           {{ end }}

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -6,6 +6,8 @@
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
+{{ $uptimeHistogramEnabled := .Site.Params.enableUptimeHistogram }}
+
 <!-- The main categories layout -->
 <div class="categories">
 	{{ $systems := .Site.Params.systems }}
@@ -17,8 +19,20 @@
 		{{ if not .untitled }}
 		<div class="bold padding clicky category__head" onclick="toggleCategoryHead(this)">
 			<span class="hide-without-js">
-				<span class="category__closed-marker">►</span>
-				<span class="category__open-marker">▲</span>
+				<span class="category__closed-marker">
+					<span class="sr-only">{{ T "openDropdown" }}</span>
+					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+						stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-right">
+						<polyline points="9 18 15 12 9 6"></polyline>
+					</svg>
+				</span>
+				<span class="category__open-marker">
+					<span class="sr-only">{{ T "closeDropdown" }}</span>
+					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+						stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down">
+						<polyline points="6 9 12 15 18 9"></polyline>
+					</svg>
+				</span>
 			</span>
 			<b>{{ .name }}</b>
 			{{ with .description }}
@@ -43,7 +57,7 @@
 
 			<div class="component" id="system-{{ .name | urlize }}"
 				data-status="{{ if $thisIsDown }}down{{ else if $thisIsDisrupted }}disrupted{{ else if $thisIsNotice }}notice{{ else }}ok{{ end }}">
-				<a href="{{ printf " affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
+				<a href="{{ printf "affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
 					{{ default $system.name $system.displayName }}
 				</a>
 
@@ -72,11 +86,14 @@
 					{{ end }}
 				</span>
 
-				<!-- HISTOGRAM: place it above the partial -->
-				<div class="histogram-container" style="margin-top:10px;">
-					<!-- A quick loading text, removed once data is fetched -->
-					<div id="histogram-{{ .name | urlize }}" class="histogram">Loading {{ .name }} uptime…</div>
-				</div>
+				{{ if $uptimeHistogramEnabled }}
+					{{ if ne $system.histogram false }}
+					<div class="histogram-container">
+						<!-- A quick loading text, removed once data is fetched -->
+						<div id="histogram-{{ .name | urlize }}" class="histogram">{{ T "laoding" }} {{ .name }} {{ T "chart" }}</div>
+					</div>
+					{{ end }}
+				{{ end }}
 
 				{{ with $system.partial }}
 				<div>
@@ -123,10 +140,14 @@
 	{{ end }}
 </div>
 
+
+
+{{ if $uptimeHistogramEnabled }}
 <!-- HISTOGRAM STYLES -->
 <style>
 	.histogram-container {
 		width: 100%;
+		margin-top: 10px;
 	}
 
 	.histogram {
@@ -289,3 +310,4 @@
 		});
 	})();
 </script>
+{{ end }}

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -22,7 +22,7 @@
       <b>
         {{ .name }}
       </b>
-      
+
       {{ with .description }}
         <span class="tooltip tooltip--small">
           &nbsp; <span class="faded">(?)</span>
@@ -32,7 +32,7 @@
           </span>
         </span>
       {{ end }}
- 
+
       <span class="category-status"></span>
 
       </div>
@@ -94,23 +94,23 @@
           {{ end }}
         </div>
       {{ end }}
-      </div> 
+      </div>
 
       <!--
         Get category status
       -->
       <script>
         // We will look at all components in one category
-        thisCategory = document.currentScript.parentNode 
+        thisCategory = document.currentScript.parentNode
 
         componentsOfThisCategory = thisCategory.querySelectorAll('.component')
-        
+
         // We will cycle through all components and show
         // the worst status found
         //
         // By default, all is good but we change this value
         // for progressively worse statuses
-        var highestLevelStatus = '';
+        var highestLevelStatus = 'ok';
 
         function checkStatus(element) {
           var status = element.getAttribute('data-status');
@@ -125,16 +125,16 @@
         }
 
         componentsOfThisCategory.forEach(element => checkStatus(element));
-        
+
         // Human readable (i18n) status name variable
         var highestLevelStatusReadable = highestLevelStatus;
 
-        if (highestLevelStatus === 'ok') { highestLevelStatusReadable = '{{ T "thisIsOk" }}' } 
-        if (highestLevelStatus === 'notice') { highestLevelStatusReadable = '{{ T "thisIsNotice" }}' } 
-        if (highestLevelStatus === 'disrupted') { highestLevelStatusReadable = '{{ T "thisIsDisrupted" }}' } 
-        if (highestLevelStatus === 'down') { highestLevelStatusReadable = '{{ T "thisIsDown" }}' } 
+        if (highestLevelStatus === 'ok') { highestLevelStatusReadable = '{{ T "thisIsOk" }}' }
+        if (highestLevelStatus === 'notice') { highestLevelStatusReadable = '{{ T "thisIsNotice" }}' }
+        if (highestLevelStatus === 'disrupted') { highestLevelStatusReadable = '{{ T "thisIsDisrupted" }}' }
+        if (highestLevelStatus === 'down') { highestLevelStatusReadable = '{{ T "thisIsDown" }}' }
 
-        // Finally we can show the status 
+        // Finally we can show the status
         // (but only for categories with a name)
         if (thisCategory.classList.contains('category--titled')) {
           thisCategory.querySelector('.category__head').setAttribute('data-status', highestLevelStatus);

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -1,3 +1,4 @@
+{{/* Existing cState references */}}
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
 {{ $active := where $incidents "Params.resolved" "=" false }}
 
@@ -5,143 +6,286 @@
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
-<!-- Individual info -->
+<!-- The main categories layout -->
 <div class="categories">
-  {{ $systems := .Site.Params.systems }}
-  {{ $categories := .Site.Params.categories }}
+	{{ $systems := .Site.Params.systems }}
+	{{ $categories := .Site.Params.categories }}
 
-  {{ range $categories }}
-    <div class="category {{ if .closed }}category--closed{{ else }}category--open{{ end }}{{ if not .untitled }} category--titled{{ end }}" id="{{ .name | urlize }}">
-      {{ if not .untitled }}
-      <div class="bold padding clicky category__head" onclick="toggleCategoryHead(this)">
-        <span class="hide-without-js">
-          <span class="category__closed-marker">►</span>
-          <span class="category__open-marker">▲</span>
-        </span>
+	{{ range $categories }}
+	<div class="category {{ if .closed }}category--closed{{ else }}category--open{{ end }}{{ if not .untitled }} category--titled{{ end }}"
+		id="{{ .name | urlize }}">
+		{{ if not .untitled }}
+		<div class="bold padding clicky category__head" onclick="toggleCategoryHead(this)">
+			<span class="hide-without-js">
+				<span class="category__closed-marker">►</span>
+				<span class="category__open-marker">▲</span>
+			</span>
+			<b>{{ .name }}</b>
+			{{ with .description }}
+			<span class="tooltip tooltip--small">
+				&nbsp; <span class="faded">(?)</span>
+				<span class="tooltip__text">{{ . }}</span>
+			</span>
+			{{ end }}
+			<span class="category-status"></span>
+		</div>
+		{{ else }}
+		<div class="padding"></div>
+		{{ end }}
 
-      <b>
-        {{ .name }}
-      </b>
+		{{ $categorySystems := where $systems "category" "=" .name }}
+		<div class="components">
+			{{ range $system := $categorySystems }}
+			{{ $activeComponentIssues := where $active "Params.affected" "intersect" (slice $system.name) }}
+			{{ $thisIsNotice := where $activeComponentIssues "Params.severity" "=" "notice" }}
+			{{ $thisIsDisrupted := where $activeComponentIssues "Params.severity" "=" "disrupted" }}
+			{{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
-      {{ with .description }}
-        <span class="tooltip tooltip--small">
-          &nbsp; <span class="faded">(?)</span>
+			<div class="component" id="system-{{ .name | urlize }}"
+				data-status="{{ if $thisIsDown }}down{{ else if $thisIsDisrupted }}disrupted{{ else if $thisIsNotice }}notice{{ else }}ok{{ end }}">
+				<a href="{{ printf " affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
+					{{ default $system.name $system.displayName }}
+				</a>
 
-          <span class="tooltip__text">
-            {{ . }}
-          </span>
-        </span>
-      {{ end }}
+				{{ with $system.description }}
+				<span class="tooltip tooltip--small">
+					&nbsp; <span class="faded">(?)</span>
+					<span class="tooltip__text">{{ . }}</span>
+				</span>
+				{{ end }}
 
-      <span class="category-status"></span>
+				{{ with $system.link }}
+				<span class="span-icon">
+					<a href="{{ . }}" class="link-style">🔗</a>
+				</span>
+				{{ end }}
 
-      </div>
-      {{ else }}
-      <div class="padding"></div>
-      {{ end }}
+				<span class="component-status">
+					{{ if $thisIsDown }}
+					{{ T "thisIsDown" }}
+					{{ else if $thisIsDisrupted }}
+					{{ T "thisIsDisrupted" }}
+					{{ else if $thisIsNotice }}
+					{{ T "thisIsNotice" }}
+					{{ else }}
+					{{ T "thisIsOk" }}
+					{{ end }}
+				</span>
 
-      {{ $categorySystems := where $systems "category" "=" .name }}
+				<!-- HISTOGRAM: place it above the partial -->
+				<div class="histogram-container" style="margin-top:10px;">
+					<!-- A quick loading text, removed once data is fetched -->
+					<div id="histogram-{{ .name | urlize }}" class="histogram">Loading {{ .name }} uptime…</div>
+				</div>
 
-      <div class="components">
-      {{ range $system := $categorySystems }}
-        {{ $activeComponentIssues := where $active "Params.affected" "intersect" (slice $system.name) }}
+				{{ with $system.partial }}
+				<div>
+					{{ partial . (dict "system" $system "incidents" $incidents) }}
+				</div>
+				{{ end }}
+			</div>
+			{{ end }}
+		</div>
 
-        {{ $thisIsNotice := where $activeComponentIssues "Params.severity" "=" "notice" }}
-        {{ $thisIsDisrupted := where $activeComponentIssues "Params.severity" "=" "disrupted" }}
-        {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
+		<!-- Category-level script to compute worst status -->
+		<script>
+			(function () {
+				var thisCategory = document.currentScript.parentNode;
+				var componentsOfThisCategory = thisCategory.querySelectorAll('.component');
+				var highestLevelStatus = 'ok';
 
-        <div class="component" id="system-{{ .name | urlize }}" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
-          <a href="{{ printf "affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
-            {{ default $system.name $system.displayName }}
-          </a>
+				function checkStatus(element) {
+					var status = element.getAttribute('data-status');
+					if (status === 'down') {
+						highestLevelStatus = 'down';
+					} else if (status === 'disrupted' && highestLevelStatus !== 'down') {
+						highestLevelStatus = 'disrupted';
+					} else if (status === 'notice' && highestLevelStatus !== 'down' && highestLevelStatus !== 'disrupted') {
+						highestLevelStatus = 'notice';
+					}
+				}
 
-          {{ with $system.description }}
-            <span class="tooltip tooltip--small">
-              &nbsp; <span class="faded">(?)</span>
+				componentsOfThisCategory.forEach(checkStatus);
 
-              <span class="tooltip__text">
-                {{ . }}
-              </span>
-            </span>
-          {{ end }}
+				var highestLevelStatusReadable = highestLevelStatus;
+				if (highestLevelStatus === 'ok') highestLevelStatusReadable = '{{ T "thisIsOk" }}';
+				else if (highestLevelStatus === 'notice') highestLevelStatusReadable = '{{ T "thisIsNotice" }}';
+				else if (highestLevelStatus === 'disrupted') highestLevelStatusReadable = '{{ T "thisIsDisrupted" }}';
+				else if (highestLevelStatus === 'down') highestLevelStatusReadable = '{{ T "thisIsDown" }}';
 
-          {{ with $system.link }}
-            <span class="span-icon">
-              <a href="{{ . }}" class="link-style">
-                🔗
-              </a>
-            </span>
-          {{ end }}
-
-          <span class="component-status">
-            {{ if $thisIsDown }}
-              {{ T "thisIsDown" }}
-            {{ else }}
-            {{ if $thisIsDisrupted }}
-              {{ T "thisIsDisrupted" }}
-            {{ else }}
-            {{ if $thisIsNotice }}
-              {{ T "thisIsNotice" }}
-            {{ else }}
-              {{ T "thisIsOk" }}
-            {{ end }}{{ end }}{{ end }}
-          </span>
-
-          {{ with $system.partial }}
-          <div>
-            {{ partial . (dict "system" $system "incidents" $incidents) }}
-          </div>
-          {{ end }}
-        </div>
-      {{ end }}
-      </div>
-
-      <!--
-        Get category status
-      -->
-      <script>
-        // We will look at all components in one category
-        thisCategory = document.currentScript.parentNode
-
-        componentsOfThisCategory = thisCategory.querySelectorAll('.component')
-
-        // We will cycle through all components and show
-        // the worst status found
-        //
-        // By default, all is good but we change this value
-        // for progressively worse statuses
-        var highestLevelStatus = 'ok';
-
-        function checkStatus(element) {
-          var status = element.getAttribute('data-status');
-
-          if (status === 'down') {
-            highestLevelStatus = 'down'
-          } else if (status === 'disrupted' && highestLevelStatus !== 'down') {
-            highestLevelStatus = 'disrupted'
-          } else if (status === 'notice' && highestLevelStatus !== 'down' && highestLevelStatus !== 'disrupted') {
-            highestLevelStatus = 'notice'
-          }
-        }
-
-        componentsOfThisCategory.forEach(element => checkStatus(element));
-
-        // Human readable (i18n) status name variable
-        var highestLevelStatusReadable = highestLevelStatus;
-
-        if (highestLevelStatus === 'ok') { highestLevelStatusReadable = '{{ T "thisIsOk" }}' }
-        if (highestLevelStatus === 'notice') { highestLevelStatusReadable = '{{ T "thisIsNotice" }}' }
-        if (highestLevelStatus === 'disrupted') { highestLevelStatusReadable = '{{ T "thisIsDisrupted" }}' }
-        if (highestLevelStatus === 'down') { highestLevelStatusReadable = '{{ T "thisIsDown" }}' }
-
-        // Finally we can show the status
-        // (but only for categories with a name)
-        if (thisCategory.classList.contains('category--titled')) {
-          thisCategory.querySelector('.category__head').setAttribute('data-status', highestLevelStatus);
-          thisCategory.querySelector('.category-status').innerHTML = highestLevelStatusReadable;
-        }
-      </script>
-    </div>
-  {{ end }}
-
+				if (thisCategory.classList.contains('category--titled')) {
+					thisCategory.querySelector('.category__head').setAttribute('data-status', highestLevelStatus);
+					thisCategory.querySelector('.category-status').innerHTML = highestLevelStatusReadable;
+				}
+			})();
+		</script>
+	</div>
+	{{ end }}
 </div>
+
+<!-- HISTOGRAM STYLES -->
+<style>
+	.histogram-container {
+		width: 100%;
+	}
+
+	.histogram {
+		display: flex;
+		flex-wrap: nowrap;
+		align-items: flex-end;
+		/* 50 bars in total. We'll just always build 60. */
+		height: 30px;
+		/* slightly shorter */
+		box-sizing: border-box;
+		/* no forced background => better for dark mode */
+	}
+
+	.histogram-bar {
+		flex: 1;
+		/* each bar has equal width */
+		margin: 0 2px;
+		height: 30px;
+		border: none;
+		position: relative;
+		cursor: pointer;
+		transition: background-color 0.2s;
+	}
+
+	.histogram-bar:hover::after {
+		display: block;
+	}
+
+	.histogram-bar::after {
+		content: attr(data-label);
+		position: absolute;
+		bottom: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		border-radius: 4px;
+		box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+		color: #fff;
+		background-color: #000;
+		padding: 2px 6px;
+		font-size: 12px;
+		border-radius: 3px;
+		display: none;
+		pointer-events: none;
+		white-space: nowrap;
+	}
+
+	/* Show all 50 on desktop; only 30 on mobile/tablet (max-width: 640px) */
+	@media (max-width: 640px) {
+		/* Hide the oldest 20 bars from the left, keep the newest 30 bars on the right */
+		.histogram-bar:nth-child(-n+20) {
+			display: none;
+		}
+	}
+</style>
+
+<!-- HISTOGRAM SCRIPT -->
+<script>
+	// Colors from your site/theme
+	var themeOkColor = '{{ .Site.Params.ok }}';
+	var themeDisruptedColor = '{{ .Site.Params.disrupted }}';
+	var themeDownColor = '{{ .Site.Params.down }}';
+
+	// We'll always build 60 bars
+	const DAYS = 60;
+
+	(function () {
+		var components = document.querySelectorAll('.component');
+		components.forEach(function (component) {
+			var systemName = component.id.replace('system-', '');
+			var histogramDiv = document.getElementById('histogram-' + systemName);
+			if (!histogramDiv) return;
+
+			// Example endpoint
+			var endpoint = '{{ .Site.BaseURL }}affected/' + systemName + '/index.json';
+			fetch(endpoint)
+				.then(res => res.json())
+				.then(data => {
+					histogramDiv.textContent = ''; // Clear "Loading..."
+
+					// We'll keep track of each day with a "worstSeverity" = "ok" / "disrupted" / "down"
+					var now = new Date();
+					var dayStats = [];
+					for (var i = 0; i < DAYS; i++) {
+						var d = new Date(now);
+						d.setDate(d.getDate() - i);
+						var y = d.getFullYear();
+						var m = String(d.getMonth() + 1).padStart(2, '0');
+						var dd = String(d.getDate()).padStart(2, '0');
+						var dateStr = y + '-' + m + '-' + dd;
+						dayStats.push({
+							dateStr: dateStr,
+							worstSeverity: 'ok' /* by default */
+						});
+					}
+
+					var incidents = data.pages || [];
+					incidents.forEach(incident => {
+						var severity = (incident.severity || '').toLowerCase();
+						// If it's not "down" or "disrupted," no need to color the day as special
+						if (severity !== 'down' && severity !== 'disrupted') return;
+
+						var startTime = new Date(incident.createdAt);
+						var endTime = incident.resolved ? new Date(incident.resolvedAt) : new Date();
+
+						// Overlap each day. If any overlap => mark worstSeverity
+						dayStats.forEach(ds => {
+							var dayStart = new Date(ds.dateStr + 'T00:00:00Z');
+							var dayEnd = new Date(ds.dateStr + 'T23:59:59Z');
+
+							var overlapStart = (startTime > dayStart) ? startTime : dayStart;
+							var overlapEnd = (endTime < dayEnd) ? endTime : dayEnd;
+							if (overlapEnd > overlapStart) {
+								// If it's "down," that's the worst.
+								// If it's "disrupted" and worst is not "down," set to "disrupted."
+								if (severity === 'down') {
+									ds.worstSeverity = 'down';
+								} else if (severity === 'disrupted' && ds.worstSeverity !== 'down') {
+									ds.worstSeverity = 'disrupted';
+								}
+							}
+						});
+					});
+
+					// Now build 60 bars, from oldest on the left to newest on the right
+					for (let i = dayStats.length - 1; i >= 0; i--) {
+						let ds = dayStats[i];
+						let bar = document.createElement('a');
+						bar.href = '{{ .Site.BaseURL }}/affected/' + systemName;
+						bar.className = 'histogram-bar';
+
+						// Determine localized label from severity
+						let labelText;
+						if (ds.worstSeverity === 'down') {
+							labelText = '{{ T "thisIsDown" }}';        // e.g. "Down"
+						} else if (ds.worstSeverity === 'disrupted') {
+							labelText = '{{ T "thisIsDisrupted" }}';   // e.g. "Disrupted"
+						} else {
+							labelText = '{{ T "thisIsOk" }}';          // e.g. "Operational"
+						}
+
+						// Full tooltip: dateStr + localized severity
+						bar.setAttribute('data-label', ds.dateStr + ' — ' + labelText);
+
+						// Assign color by worstSeverity
+						if (ds.worstSeverity === 'down') {
+							bar.style.backgroundColor = themeDownColor;
+						} else if (ds.worstSeverity === 'disrupted') {
+							bar.style.backgroundColor = themeDisruptedColor;
+						} else {
+							bar.style.backgroundColor = themeOkColor;
+						}
+
+						histogramDiv.appendChild(bar);
+					}
+				})
+				.catch(err => {
+					histogramDiv.textContent = 'Error loading data for ' + systemName;
+					console.error('Histogram load error:', systemName, err);
+				});
+		});
+	})();
+</script>

--- a/layouts/partials/index/components.html
+++ b/layouts/partials/index/components.html
@@ -50,7 +50,7 @@
         {{ $thisIsDisrupted := where $activeComponentIssues "Params.severity" "=" "disrupted" }}
         {{ $thisIsDown := where $activeComponentIssues "Params.severity" "=" "down" }}
 
-        <div class="component" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
+        <div class="component" id="system-{{ .name | urlize }}" data-status="{{ if $thisIsDown }}down{{ else }}{{ if $thisIsDisrupted }}disrupted{{ else }}{{ if $thisIsNotice }}notice{{ else }}ok{{ end }}{{ end }}{{ end }}">
           <a href="{{ printf "affected/%s/" ($system.name | urlize) | relURL }}" class="no-underline">
             {{ default $system.name $system.displayName }}
           </a>

--- a/layouts/partials/index/incidents-paginated.html
+++ b/layouts/partials/index/incidents-paginated.html
@@ -1,0 +1,61 @@
+{{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
+{{ $active := where $incidents "Params.resolved" "=" false }}
+
+{{ $isNotice := where $active "Params.severity" "=" "notice" }}
+{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
+{{ $isDown := where $active "Params.severity" "=" "down" }}
+
+<!-- Pagination is also included with incidents -->
+
+{{ if not $incidents }}
+  <div class="padding"></div>
+  <h3>{{ T "calmBeforeTheStorm" }}</h3>
+  <p>{{ T "noIncidentsDesc" }}</p>
+  <div class="padding"></div>
+  <div class="padding"></div>
+  <div class="padding"></div>
+{{ else }}
+  {{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
+  {{ range $paginator.Pages }}
+    {{ .Render "small" }}
+  {{ end }}
+
+  <!-- If there are more than 2 pages, show pagination -->
+  {{ if gt $paginator.TotalPages 1 }}
+    <hr>
+
+    <div class="center">
+      {{ if $paginator.HasPrev }}
+        <a href="{{ $paginator.Prev.URL }}#incidents">
+          ← &nbsp;
+          {{ T "prev" }}
+        </a>
+      {{ else }}
+        <span class="faded">
+          ← &nbsp;
+          {{ T "prev" }}
+        </span>
+      {{ end }}
+
+
+      &nbsp; &nbsp;
+      {{ $paginator.PageNumber }}
+      /
+      {{ $paginator.TotalPages }}
+      &nbsp; &nbsp;
+
+
+      {{ if $paginator.HasNext }}
+        <a href="{{ $paginator.Next.URL }}#incidents">
+          {{ T "next" }} &nbsp;
+          →
+        </a>
+      {{ else }}
+        <span class="faded">
+          {{ T "next" }} &nbsp;
+          →
+        </span>
+      {{ end }}
+    </div>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/index/incidents-yearly.html
+++ b/layouts/partials/index/incidents-yearly.html
@@ -11,7 +11,7 @@ correctly.
 - Cast to integer
 - If casting fails (e.g., non-numeric value), set to 0
 */}}
-{{ $maxAgeYears := .Site.Params.incidentMaxAgeYears | default 6 | int }}
+{{ $maxAgeYears := .Site.Params.incidentMaxAgeYears | int }}
 
 {{/* Step 3: Initialize a variable to hold incidents to display */}}
 {{ $displayIncidents := $incidents }}

--- a/layouts/partials/index/incidents-yearly.html
+++ b/layouts/partials/index/incidents-yearly.html
@@ -1,13 +1,70 @@
+{{/*
+Template to display incidents grouped by year, excluding those older than a specified number of years if configured
+correctly.
+*/}}
+
+{{/* Step 1: Retrieve all incidents */}}
 {{ $incidents := where .Site.RegularPages "Params.section" "issue" }}
 
+{{/* Step 2: Attempt to retrieve and cast maximum age in years from config */}}
+{{/*
+- Cast to integer
+- If casting fails (e.g., non-numeric value), set to 0
+*/}}
+{{ $maxAgeYears := .Site.Params.incidentMaxAgeYears | default 6 | int }}
 
-{{ range ($incidents.GroupByDate "2006") }}
-  
-  <p class="center archive__head" id="archive-{{ .Key }}"><a href="#archive-{{ .Key }}" class="no-underline"><strong>{{ .Key }}</strong>
-    <span class="faded">({{ len .Pages }})</span>
-  </a></p>
-  
-  {{ range .Pages }}
-    {{ .Render "small" }}
-  {{ end }}
+{{/* Step 3: Initialize a variable to hold incidents to display */}}
+{{ $displayIncidents := $incidents }}
+
+{{/* Step 4: Conditionally filter incidents if $maxAgeYears is greater than 0 */}}
+{{ if gt $maxAgeYears 0 }}
+{{/* Calculate the cutoff date */}}
+{{ $currentDate := now }}
+{{ $cutoffYear := sub $currentDate.Year $maxAgeYears }}
+{{ $cutoffDateString := printf "%d-%02d-%02d" $cutoffYear $currentDate.Month $currentDate.Day }}
+{{ $cutoffDate := $cutoffDateString | time }}
+
+{{/* Filter incidents to include only those newer than the cutoff date */}}
+{{ $filteredIncidents := where $incidents "Date" "ge" $cutoffDate }}
+
+{{/* Update $displayIncidents to the filtered list */}}
+{{ $displayIncidents = $filteredIncidents }}
+{{ end }}
+
+{{/* Step 5: Check if there are any incidents to display */}}
+{{ if not $displayIncidents }}
+<div class="padding"></div>
+<h3>{{ T "calmBeforeTheStorm" }}</h3>
+<p>{{ T "noIncidentsDesc" }}</p>
+<div class="padding"></div>
+<div class="padding"></div>
+<div class="padding"></div>
+{{ else }}
+{{/* Step 6: Group the incidents by year */}}
+{{ range ($displayIncidents.GroupByDate "2006") }}
+<p class="center archive__head" id="archive-{{ .Key }}">
+	<a href="#archive-{{ .Key }}" class="no-underline">
+		<strong>{{ .Key }}</strong>
+		<span class="faded">({{ len .Pages }})</span>
+	</a>
+</p>
+
+{{/* Step 7: Render each incident in the group */}}
+{{ range .Pages }}
+{{ .Render "small" }}
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{/* Step 8: Show the notice if filtering is applied */}}
+{{ if gt $maxAgeYears 0 }}
+<div class="padding"></div>
+<div class="padding"></div>
+<div class="padding"></div>
+
+<div class="center">
+	<small class="faded">
+		{{ i18n "incidentMaxAgeNotice" (dict "MaxAgeYears" $maxAgeYears) }}
+	</small>
+</div>
 {{ end }}

--- a/layouts/partials/index/incidents.html
+++ b/layouts/partials/index/incidents.html
@@ -5,57 +5,31 @@
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
-<!-- Pagination is also included with incidents -->
+<!-- Define the number of posts per page -->
+{{ $postsPerPage := .Site.Params.incidentPostsPerPage | default 10 }}
 
 {{ if not $incidents }}
-  <div class="padding"></div>
-  <h3>{{ T "calmBeforeTheStorm" }}</h3>
-  <p>{{ T "noIncidentsDesc" }}</p>
-  <div class="padding"></div>
-  <div class="padding"></div>
-  <div class="padding"></div>
+<div class="padding"></div>
+<h3>{{ T "calmBeforeTheStorm" }}</h3>
+<p>{{ T "noIncidentsDesc" }}</p>
+<div class="padding"></div>
+<div class="padding"></div>
+<div class="padding"></div>
 {{ else }}
-  {{ $paginator := .Paginate $incidents .Site.Params.incidentPostsPerPage }}
-  {{ range $paginator.Pages }}
-    {{ .Render "small" }}
-  {{ end }}
+<!-- Limit the displayed incidents to the configured number per page -->
+{{ $limitedIncidents := first $postsPerPage $incidents }}
 
-  <!-- If there are more than 2 pages, show pagination -->
-  {{ if gt $paginator.TotalPages 1 }}
-    <hr>
+{{ range $limitedIncidents }}
+{{ .Render "small" }}
+{{ end }}
 
-    <div class="center">
-      {{ if $paginator.HasPrev }}
-        <a href="{{ $paginator.Prev.URL }}#incidents">
-          ← &nbsp;
-          {{ T "prev" }}
-        </a>
-      {{ else }}
-        <span class="faded">
-          ← &nbsp;
-          {{ T "prev" }}
-        </span>
-      {{ end }}
-
-
-      &nbsp; &nbsp;
-      {{ $paginator.PageNumber }}
-      /
-      {{ $paginator.TotalPages }}
-      &nbsp; &nbsp;
-
-
-      {{ if $paginator.HasNext }}
-        <a href="{{ $paginator.Next.URL }}#incidents">
-          {{ T "next" }} &nbsp;
-          →
-        </a>
-      {{ else }}
-        <span class="faded">
-          {{ T "next" }} &nbsp;
-          →
-        </span>
-      {{ end }}
-    </div>
-  {{ end }}
+<!-- Check if there are more incidents than the posts per page -->
+{{ if gt (len $incidents) $postsPerPage }}
+<hr>
+<div class="right">
+	<a href="/issues/" class="next-link">
+		{{ T "next" }} &nbsp; &rarr;
+	</a>
+</div>
+{{ end }}
 {{ end }}

--- a/layouts/partials/index/summary.html
+++ b/layouts/partials/index/summary.html
@@ -5,20 +5,492 @@
 {{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}
 {{ $isDown := where $active "Params.severity" "=" "down" }}
 
-<div class="summary">
-  <strong>
-    {{ if $isDown }}
-      {{ T "isDown" }}
-    {{ else }}
-    {{ if $isDisrupted }}
-      {{ T "isDisrupted" }}
-    {{ else }}
-    {{ if $isNotice }}
-      {{ T "isNotice" }}
-    {{ else }}
-      {{ T "isOk" }}
-    {{ end }}{{ end }}{{ end }}
-  </strong>
+<div class="summary status-box">
+	<div class="summary-flex">
+		<div class="status-text">
+			<strong>
+				{{ if $isDown }}
+				{{ T "isDown" }}
+				{{ else if $isDisrupted }}
+				{{ T "isDisrupted" }}
+				{{ else if $isNotice }}
+				{{ T "isNotice" }}
+				{{ else }}
+				{{ T "isOk" }}
+				{{ end }}
+			</strong>
+			<div class="summary__date clicky relative-time" onclick="location.reload()" data-time-prefix="{{ T "lastChecked" }} "
+      ></div>
+    </div>
 
-  <div class="summary__date clicky float-right relative-time" onclick="location.reload()" data-time-prefix="{{ T "lastChecked" }} "></div>
-</div>
+    <!-- Subscribe button (no icon) -->
+    <div class=" subscribe-wrapper">
+				<button class="subscribe-button" aria-haspopup="true" aria-expanded="false" aria-label="{{ T "openDropdown" }}">
+					{{ T "subscribe" }}
+				</button>
+				<div class="subscribe-dropdown hidden" aria-label="{{ T "closeDropdown" }}">
+					<ul>
+						<a href="{{ .Site.BaseURL }}/index.xml" target="_blank" rel="noopener noreferrer">
+						<li>
+							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
+								<path d="M108.56 342.78a60.34 60.34 0 1 0 60.56 60.44 60.63 60.63 0 0 0-60.56-60.44Z">
+								</path>
+								<path
+									d="M48 186.67v86.55c52 0 101.94 15.39 138.67 52.11s52 86.56 52 138.67h86.66c0-151.56-125.66-277.33-277.33-277.33Z">
+								</path>
+								<path
+									d="M48 48v86.56c185.25 0 329.22 144.08 329.22 329.44H464C464 234.66 277.67 48 48 48Z">
+								</path>
+							</svg>
+							{{ T "rss" }}
+						</li></a>
+						{{ if .Site.Params.monitorBot }}
+						<li data-option="email">
+							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
+								<path
+									d="M424 80H88a56 56 0 0 0-56 56v240a56 56 0 0 0 56 56h336a56 56 0 0 0 56-56V136a56 56 0 0 0-56-56zm-14.18 92.63-144 112a16 16 0 0 1-19.64 0l-144-112a16 16 0 1 1 19.64-25.26L256 251.73l134.18-104.36a16 16 0 1 1 19.64 25.26z">
+								</path>
+							</svg>
+							{{ T "email" }}
+						</li>
+						<li data-option="discord">
+							<svg viewBox="0 0 128 97" class="subscribe-dropdown__icon">
+								<path
+									d="M107.7 8.07A105.152 105.152 0 0 0 81.47 0a72.073 72.073 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.375 72.375 0 0 0 45.64 0a105.89 105.89 0 0 0-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.418 68.418 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.255 105.255 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15ZM42.45 65.69C36.18 65.69 31 60 31 53c0-7 5-12.74 11.43-12.74S54 46 53.89 53c-.11 7-5.05 12.69-11.44 12.69Zm42.24 0C78.41 65.69 73.25 60 73.25 53c0-7 5-12.74 11.44-12.74 6.44 0 11.54 5.74 11.43 12.74-.11 7-5.04 12.69-11.43 12.69Z">
+								</path>
+							</svg>
+							{{ T "discord" }}
+						</li>
+						<li data-option="slack">
+							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
+								<path
+									d="M126.12 315.1A47.06 47.06 0 1 1 79.06 268h47.06zm23.72 0a47.06 47.06 0 0 1 94.12 0v117.84a47.06 47.06 0 1 1-94.12 0zm47.06-188.98A47.06 47.06 0 1 1 244 79.06v47.06zm0 23.72a47.06 47.06 0 0 1 0 94.12H79.06a47.06 47.06 0 0 1 0-94.12zm188.98 47.06a47.06 47.06 0 1 1 47.06 47.1h-47.06zm-23.72 0a47.06 47.06 0 0 1-94.12 0V79.06a47.06 47.06 0 0 1 94.12 0zM315.1 385.88a47.06 47.06 0 1 1-47.1 47.06v-47.06zm0-23.72a47.06 47.06 0 0 1 0-94.12h117.84a47.06 47.06 0 1 1 0 94.12z">
+								</path>
+							</svg>
+							{{ T "slack" }}
+						</li>
+						<li data-option="webhook">
+							<svg viewBox="0 0 58 52" class="subscribe-dropdown__icon">
+								<path fill-rule="evenodd" clip-rule="evenodd"
+									d="M37.474 18.014A10.955 10.955 0 0 0 40 11c0-6.075-4.925-11-11-11S18 4.925 18 11c0 2.918 1.136 5.57 2.99 7.538l-6.876 11.909A11.003 11.003 0 0 0 11 30C4.925 30 0 34.925 0 41s4.925 11 11 11c4.851 0 8.97-3.14 10.431-7.5H36.57C38.03 48.86 42.149 52 47 52c6.075 0 11-4.925 11-11s-4.925-11-11-11c-.842 0-1.661.095-2.449.273l-7.077-12.259ZM25.16 21.312l-6.7 11.605a10.976 10.976 0 0 1 3.438 6.583H36.1a10.986 10.986 0 0 1 3.948-7.026l-6.59-11.415A10.96 10.96 0 0 1 29 22c-1.35 0-2.644-.243-3.839-.688Z">
+								</path>
+							</svg>
+							{{ T "webhook" }}
+						</li>
+						{{ end }}
+						<li data-option="push">
+							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
+								<path
+									d="M256 0c-42.1 0-76.2 34.1-76.2 76.2v29.3c-64.5 17.2-112.1 75.3-112.1 145v70.7L32.1 384v28.6h447.8V384l-35.6-62.8v-70.7c0-69.7-47.6-127.8-112.1-145V76.2C332.2 34.1 298.1 0 256 0zm-23.4 444.2h46.8c0 12.9-10.5 23.4-23.4 23.4-12.9 0-23.4-10.5-23.4-23.4z">
+								</path>
+							</svg>
+							{{ T "pushNotifications" }}
+						</li>
+						<li data-option="api">
+							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
+								<path
+									d="M160 389a20.91 20.91 0 0 1-13.82-5.2l-128-112a21 21 0 0 1 0-31.6l128-112a21 21 0 0 1 27.66 31.61L63.89 256l109.94 96.19A21 21 0 0 1 160 389zm192 0a21 21 0 0 1-13.84-36.81L448.11 256l-109.94-96.19a21 21 0 0 1 27.66-31.61l128 112a21 21 0 0 1 0 31.6l-128 112A20.89 20.89 0 0 1 352 389zm-144 48a21 21 0 0 1-20.12-27l96-320a21 21 0 1 1 40.23 12l-96 320A21 21 0 0 1 208 437z">
+								</path>
+							</svg>
+							{{ T "API" }}
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Modal -->
+	<div id="modal-overlay" class="hidden"></div>
+	<div class="subscribe-modal hidden" role="dialog" aria-modal="true">
+		<button class="subscribe-modal__close" aria-label="{{ T "closeDropdown" }}">✕</button>
+		<h2 class="subscribe-modal__title"></h2>
+		<div class="subscribe-modal__content"></div>
+		<!-- Additional area for disclaimers/buttons -->
+		<div class="subscribe-modal__actions"></div>
+	</div>
+
+	<style>
+		/* Status box styling */
+		.status-box {
+			padding: 16px;
+			color: #fff;
+			display: flex;
+			flex-direction: column;
+			border-radius: 4px;
+			position: relative;
+
+			background: {
+					{
+					.Site.Params.ok
+				}
+			}
+
+			;
+		}
+
+		.summary-flex {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		.status-text {
+			font-size: 20px;
+			font-weight: bold;
+		}
+
+		.summary__date {
+			font-size: 14px;
+			margin-top: 4px;
+			color: rgba(255, 255, 255, 0.8);
+		}
+
+		/* Subscribe button & dropdown */
+		.subscribe-wrapper {
+			position: relative;
+			z-index: 500;
+		}
+
+		.subscribe-button {
+			padding: 8px 16px;
+			border-radius: 4px;
+			font-size: 14px;
+			cursor: pointer;
+			background: rgba(255, 255, 255, 0.2);
+			border: 1px solid rgba(255, 255, 255, 0.25);
+			color: #fff;
+			transition: background 0.1s, opacity 0.1s;
+			/* Faster transition */
+		}
+
+		.subscribe-button:hover {
+			background: rgba(255, 255, 255, 0.3);
+		}
+
+		.subscribe-button:active {
+			background: rgba(255, 255, 255, 0.4);
+		}
+
+		/* Remove icon from subscribe button => no .subscribe-button__icon inside that button */
+
+		.subscribe-dropdown {
+			position: absolute;
+			top: calc(100% + 10px);
+			right: 0;
+			background: #fff;
+			border: 1px solid #ccc;
+			border-radius: 8px;
+			width: 220px;
+			max-height: 300px;
+			/* Limit dropdown height */
+			overflow-y: auto;
+			/* Add scrollbar if needed */
+			opacity: 0;
+			transform: translateY(5px);
+			animation: fadeUp 0.15s ease-out forwards;
+			/* Faster animation with ease-out */
+			box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+			/* more spread out shadow */
+		}
+
+		.subscribe-dropdown ul {
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+
+		.subscribe-dropdown li {
+			display: flex;
+			align-items: center;
+			padding: 10px 12px;
+			font-size: 14px;
+			cursor: pointer;
+			color: #333;
+			border-radius: 8px;
+			/* apply same border rounding on hover */
+			transition: background 0.1s;
+			/* Faster transition */
+		}
+
+		.subscribe-dropdown li:hover {
+			background: #f2f2f2;
+		}
+
+		.subscribe-dropdown__icon {
+			width: 18px;
+			height: 18px;
+			margin-right: 8px;
+			fill: #999;
+			/* slightly lighter icons */
+		}
+
+		/* fadeUp animation */
+		@keyframes fadeUp {
+			0% {
+				opacity: 0;
+				transform: translateY(5px);
+			}
+
+			100% {
+				opacity: 1;
+				transform: translateY(0);
+			}
+		}
+
+		.hidden {
+			display: none !important;
+		}
+
+		/* Modal Styling */
+		#modal-overlay {
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			background-color: rgba(0, 0, 0, 0.5);
+			/* Dimmed background */
+			z-index: 998;
+			/* Ensure it's below the modal but above other content */
+		}
+
+		.subscribe-modal {
+			position: fixed;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			/* Center the modal */
+			margin: auto;
+			max-width: 600px;
+			background: #fff;
+			border-radius: 8px;
+			box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+			padding: 24px;
+			z-index: 999;
+			display: flex;
+			flex-direction: column;
+			gap: 16px;
+			opacity: 0;
+			animation: fadeUpModal 0.2s ease-out forwards;
+			/* Adjusted animation */
+		}
+
+		.subscribe-modal__close {
+			position: absolute;
+			top: 10px;
+			right: 10px;
+			border: none;
+			background: transparent;
+			font-size: 24px;
+			line-height: 1;
+			cursor: pointer;
+			color: #444;
+			padding: 4px;
+			border-radius: 50%;
+		}
+
+		.subscribe-modal__close:hover {
+			background-color: rgba(0, 0, 0, 0.1);
+		}
+
+		.subscribe-modal__close:active {
+			background-color: rgba(0, 0, 0, 0.2);
+		}
+
+		.subscribe-modal__title {
+			margin: 0 0 16px 0;
+			font-size: 20px;
+			color: #333;
+		}
+
+		.subscribe-modal__content {
+			font-size: 14px;
+			color: #555;
+			flex: 1;
+			/* allow content area to expand */
+		}
+
+		/* An extra area for disclaimers or buttons, etc. */
+		.subscribe-modal__actions {
+			margin-top: 8px;
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+		}
+
+		.subscribe-modal__actions button,
+		.subscribe-modal__actions input {
+			padding: 8px;
+			border-radius: 4px;
+			border: 1px solid #ccc;
+		}
+
+		/* Modal fade up animation */
+		@keyframes fadeUpModal {
+			0% {
+				opacity: 0;
+			}
+
+			100% {
+				opacity: 1;
+			}
+		}
+	</style>
+
+	<script>
+		document.addEventListener('DOMContentLoaded', function () {
+			const subscribeButton = document.querySelector('.subscribe-button');
+			const subscribeDropdown = document.querySelector('.subscribe-dropdown');
+			const subscribeModal = document.querySelector('.subscribe-modal');
+			const modalCloseBtn = document.querySelector('.subscribe-modal__close');
+			const modalTitle = document.querySelector('.subscribe-modal__title');
+			const modalContent = document.querySelector('.subscribe-modal__content');
+			const modalActions = document.querySelector('.subscribe-modal__actions');
+			const modalOverlay = document.getElementById('modal-overlay');
+
+			// Function to show the modal
+			function showModal() {
+				modalOverlay.classList.remove('hidden');
+				subscribeModal.classList.remove('hidden');
+			}
+
+			// Function to hide the modal
+			function hideModal() {
+				modalOverlay.classList.add('hidden');
+				subscribeModal.classList.add('hidden');
+			}
+
+			// Toggle dropdown
+			subscribeButton.addEventListener('click', function (e) {
+				e.stopPropagation();
+				if (subscribeDropdown.classList.contains('hidden')) {
+					subscribeDropdown.classList.remove('hidden');
+					subscribeButton.setAttribute('aria-expanded', 'true');
+				} else {
+					subscribeDropdown.classList.add('hidden');
+					subscribeButton.setAttribute('aria-expanded', 'false');
+				}
+			});
+
+			// Dropdown option click
+			subscribeDropdown.addEventListener('click', function (e) {
+				if (e.target && e.target.matches('li[data-option], li[data-option] *')) {
+					let li = e.target.closest('li[data-option]');
+					let chosen = li.getAttribute('data-option');
+
+					subscribeDropdown.classList.add('hidden');
+					subscribeButton.setAttribute('aria-expanded', 'false');
+					showModal();
+
+					// Clear previous actions
+					modalActions.innerHTML = '';
+
+					let copyText = ''; // Initialize copyText here
+
+					switch (chosen) {
+						case 'rss':
+							modalTitle.textContent = '{{ T "rss" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>`;
+							modalActions.innerHTML = `
+							<a href="{{ .Site.BaseURL }}/index.xml" target="_blank" rel="noopener noreferrer" class="padding-s">{{ T "open" }}</a>
+          `;
+							break;
+
+						case 'email':
+							modalTitle.textContent = '{{ T "email" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>
+            <input type="email" placeholder="Email address..." />`;
+							modalActions.innerHTML = `
+            <button>{{ T "subscribe" }}</button>
+            <p class="small-text">{{ T "pushNotificationsDisclaimer" }}</p>
+          `;
+							break;
+
+						case 'discord':
+							modalTitle.textContent = '{{ T "discord" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }} (Discord server invitation)</p>`;
+							copyText = 'YOUR_DISCORD_INVITE_LINK'; // Replace with your Discord invite link
+							modalActions.innerHTML = `
+            <button data-copy="${copyText}">{{ T "copy" }}</button>
+            <p class="small-text">{{ T "embedDisclaimer" }}</p>
+          `;
+							break;
+
+						case 'slack':
+							modalTitle.textContent = '{{ T "slack" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }} (Slack workspace link)</p>`;
+							copyText = 'YOUR_SLACK_WORKSPACE_LINK'; // Replace with your Slack workspace link
+							modalActions.innerHTML = `
+            <button data-copy="${copyText}">{{ T "copy" }}</button>
+            <p class="small-text">{{ T "embedDisclaimer" }}</p>
+          `;
+							break;
+
+						case 'webhook':
+							modalTitle.textContent = '{{ T "webhook" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>
+            <input type="text" placeholder="{{ T "webhookUrl" }}" />`;
+							modalActions.innerHTML = `
+            <button>{{ T "subscribe" }}</button>
+            <p class="small-text">{{ T "APIdisclaimer" }}</p>
+          `;
+							break;
+
+						case 'push':
+							modalTitle.textContent = '{{ T "pushNotifications" }}';
+							modalContent.innerHTML = `<p>{{ T "pushNotificationsDescription" }}</p>`;
+							modalActions.innerHTML = `
+            <button>{{ T "subscribe" }}</button>
+            <p class="small-text">{{ T "pushNotificationsDisclaimer" }}</p>
+          `;
+							break;
+
+						case 'api':
+							modalTitle.textContent = '{{ T "API" }}';
+							modalContent.innerHTML = `<p>{{ T "APIdescription" }} <br /> <code>{{ .Site.BaseURL }}index.json</code></p>`;
+							modalActions.innerHTML = `
+            <a href="https://github.com/cstate/cstate/wiki/API" target="_blank" rel="noopener noreferrer" class="padding-s">{{ T "readDocumentation" }}</a>
+            <p>{{ T "APIdisclaimer" }}</p>
+          `;
+							break;
+
+						default:
+							modalTitle.textContent = '{{ T "subscribe" }}';
+							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>`;
+							modalActions.innerHTML = `
+            <button>{{ T "subscribe" }}</button>
+            <p class="small-text">{{ T "embedDisclaimer" }}</p>
+          `;
+							break;
+					}
+
+					// Add event listeners to copy buttons
+					const copyButtons = modalActions.querySelectorAll('button[data-copy]');
+					copyButtons.forEach(button => {
+						button.addEventListener('click', () => {
+							const textToCopy = button.getAttribute('data-copy');
+							navigator.clipboard.writeText(textToCopy).then(() => {
+								// Optional: Display a success message or change button text
+								button.textContent = '{{ T "copied" }}';
+							}).catch(err => {
+								console.error('Failed to copy text:', err);
+							});
+						});
+					});
+				}
+			});
+
+			// Close modal
+			modalCloseBtn.addEventListener('click', hideModal);
+			modalOverlay.addEventListener('click', hideModal);
+
+			// Close dropdown if user clicks outside
+			document.addEventListener('click', function (e) {
+				if (!subscribeButton.contains(e.target) && !subscribeDropdown.contains(e.target)) {
+					subscribeDropdown.classList.add('hidden');
+					subscribeButton.setAttribute('aria-expanded', 'false');
+				}
+			});
+		});
+	</script>

--- a/layouts/partials/index/summary.html
+++ b/layouts/partials/index/summary.html
@@ -77,7 +77,6 @@
 							</svg>
 							{{ T "webhook" }}
 						</li>
-						{{ end }}
 						<li data-option="push">
 							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
 								<path
@@ -86,6 +85,7 @@
 							</svg>
 							{{ T "pushNotifications" }}
 						</li>
+						{{ end }}
 						<li data-option="api">
 							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
 								<path
@@ -154,14 +154,14 @@
 
 		.subscribe-button {
 			padding: 8px 16px;
+			font: inherit;
+			font-size: 15px;
 			border-radius: 4px;
-			font-size: 14px;
 			cursor: pointer;
 			background: rgba(255, 255, 255, 0.2);
 			border: 1px solid rgba(255, 255, 255, 0.25);
 			color: #fff;
 			transition: background 0.1s, opacity 0.1s;
-			/* Faster transition */
 		}
 
 		.subscribe-button:hover {
@@ -179,19 +179,13 @@
 			top: calc(100% + 10px);
 			right: 0;
 			background: #fff;
-			border: 1px solid #ccc;
 			border-radius: 8px;
 			width: 220px;
-			max-height: 300px;
-			/* Limit dropdown height */
 			overflow-y: auto;
-			/* Add scrollbar if needed */
 			opacity: 0;
 			transform: translateY(5px);
 			animation: fadeUp 0.15s ease-out forwards;
-			/* Faster animation with ease-out */
-			box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
-			/* more spread out shadow */
+			box-shadow: 0 10px 32px rgba(0, 0, 0, 0.15);
 		}
 
 		.subscribe-dropdown ul {
@@ -204,6 +198,7 @@
 			display: flex;
 			align-items: center;
 			padding: 10px 12px;
+			margin: 4px;
 			font-size: 14px;
 			cursor: pointer;
 			color: #333;
@@ -282,11 +277,11 @@
 			right: 10px;
 			border: none;
 			background: transparent;
-			font-size: 24px;
+			font-size: 20px;
 			line-height: 1;
 			cursor: pointer;
 			color: #444;
-			padding: 4px;
+			padding: 10px;
 			border-radius: 50%;
 		}
 
@@ -301,29 +296,48 @@
 		.subscribe-modal__title {
 			margin: 0 0 16px 0;
 			font-size: 20px;
+			font-weight: bold;
 			color: #333;
 		}
 
 		.subscribe-modal__content {
-			font-size: 14px;
 			color: #555;
 			flex: 1;
-			/* allow content area to expand */
 		}
+
+		.subscribe-modal__content p {
+			margin: 0;
+		}
+
+		.btn {
+			padding: 10px 20px;
+			border-radius: 4px;
+			display: inline-block;
+			border: none;
+			font-weight: bold;
+			cursor: pointer;
+			transition: background 0.1s, opacity 0.1s;
+		}
+
+		.btn--primary {
+			background: #000;
+			color: #fff;
+			border: none;
+		}
+
+		.btn--primary:hover {
+			background: #111;
+		}
+
+		.btn--primary:active {
+			background: #222;
+		}
+
 
 		/* An extra area for disclaimers or buttons, etc. */
 		.subscribe-modal__actions {
 			margin-top: 8px;
-			display: flex;
-			flex-direction: column;
 			gap: 8px;
-		}
-
-		.subscribe-modal__actions button,
-		.subscribe-modal__actions input {
-			padding: 8px;
-			border-radius: 4px;
-			border: 1px solid #ccc;
 		}
 
 		/* Modal fade up animation */
@@ -402,7 +416,7 @@
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>
             <input type="email" placeholder="Email address..." />`;
 							modalActions.innerHTML = `
-            <button>{{ T "subscribe" }}</button>
+            <button class="btn btn--primary">{{ T "subscribe" }}</button>
             <p class="small-text">{{ T "pushNotificationsDisclaimer" }}</p>
           `;
 							break;
@@ -412,7 +426,7 @@
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }} (Discord server invitation)</p>`;
 							copyText = 'YOUR_DISCORD_INVITE_LINK'; // Replace with your Discord invite link
 							modalActions.innerHTML = `
-            <button data-copy="${copyText}">{{ T "copy" }}</button>
+            <button class="btn btn--primary" data-copy="${copyText}">{{ T "copy" }}</button>
             <p class="small-text">{{ T "embedDisclaimer" }}</p>
           `;
 							break;
@@ -422,7 +436,7 @@
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }} (Slack workspace link)</p>`;
 							copyText = 'YOUR_SLACK_WORKSPACE_LINK'; // Replace with your Slack workspace link
 							modalActions.innerHTML = `
-            <button data-copy="${copyText}">{{ T "copy" }}</button>
+            <button class="btn btn--primary" data-copy="${copyText}">{{ T "copy" }}</button>
             <p class="small-text">{{ T "embedDisclaimer" }}</p>
           `;
 							break;
@@ -432,7 +446,7 @@
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>
             <input type="text" placeholder="{{ T "webhookUrl" }}" />`;
 							modalActions.innerHTML = `
-            <button>{{ T "subscribe" }}</button>
+            <button class="btn btn--primary">{{ T "subscribe" }}</button>
             <p class="small-text">{{ T "APIdisclaimer" }}</p>
           `;
 							break;
@@ -441,7 +455,7 @@
 							modalTitle.textContent = '{{ T "pushNotifications" }}';
 							modalContent.innerHTML = `<p>{{ T "pushNotificationsDescription" }}</p>`;
 							modalActions.innerHTML = `
-            <button>{{ T "subscribe" }}</button>
+            <button class="btn btn--primary">{{ T "subscribe" }}</button>
             <p class="small-text">{{ T "pushNotificationsDisclaimer" }}</p>
           `;
 							break;
@@ -450,7 +464,7 @@
 							modalTitle.textContent = '{{ T "API" }}';
 							modalContent.innerHTML = `<p>{{ T "APIdescription" }} <br /> <code>{{ .Site.BaseURL }}index.json</code></p>`;
 							modalActions.innerHTML = `
-            <a href="https://github.com/cstate/cstate/wiki/API" target="_blank" rel="noopener noreferrer" class="padding-s">{{ T "readDocumentation" }}</a>
+            <a href="https://github.com/cstate/cstate/wiki/API" target="_blank" rel="noopener noreferrer" class="btn btn--primary">{{ T "readDocumentation" }}</a>
             <p>{{ T "APIdisclaimer" }}</p>
           `;
 							break;
@@ -459,7 +473,7 @@
 							modalTitle.textContent = '{{ T "subscribe" }}';
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>`;
 							modalActions.innerHTML = `
-            <button>{{ T "subscribe" }}</button>
+            <button class="btn btn--primary">{{ T "subscribe" }}</button>
             <p class="small-text">{{ T "embedDisclaimer" }}</p>
           `;
 							break;

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -3,7 +3,7 @@
    * Dev toolset
    */
 
-  console.log('cState v5.6.1 - https://github.com/cstate/cstate');
+  console.log('cState v6.0 - https://github.com/cstate/cstate');
   document.getElementsByTagName('html')[0].className = 'js';
 
   /**
@@ -40,7 +40,7 @@
     document.location.pathname = '/admin';
   }
 
-  /** 
+  /**
    * Category logic
    */
 
@@ -55,7 +55,7 @@
   /**
    * Returns a relative date string for the given date.
    */
-  
+
   function timeSince(date) {
     var seconds = Math.floor((new Date() - date) / 1000);
 
@@ -98,7 +98,7 @@
    * Changes elements with the class 'relative-time' into relative times and
    * moves the timestamp to a title attribute tooltip.
    */
-  
+
   function updateRelativeTimes() {
     var elements = document.querySelectorAll('.relative-time');
     for (var i = 0; i < elements.length; i++) {

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -116,8 +116,8 @@
 
     .center { text-align: center; }
     .right { text-align: right; }
-    .padding-s { padding: 6px; }
-    .padding { padding: 12px; }
+    .padding-s { padding: 8px; }
+    .padding { padding: 16px; }
     .clicky { cursor: pointer; }
 
     .link-style { border: none; }

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -66,7 +66,6 @@
     h1, h2, h4 {
       font-weight: normal;
       color: #000;
-      font-family: "Inter", "Inter UI", "Segoe UI", BlinkMacSystemFont, -apple-system, "San Francisco Display", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       letter-spacing: -0.4px;
       overflow-wrap: break-word;
     }

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -81,7 +81,7 @@
       width: 100%;
       height: auto;
     }
-      
+
     .hidden { display: none; }
 
     /**
@@ -177,13 +177,13 @@
       font-size: 14px;
       font-variant: small-caps;
     }
-      
+
     {{ if eq .Site.Params.headerTextColor "black" }}
       .header a h1 { color: #000; }
     {{ else if eq .Site.Params.headerTextColor "white" }}
       .header a h1 { color: #fff; }
     {{ end }}
-      
+
     .header__logo img {
       height: auto;
       width: 320px;
@@ -314,10 +314,50 @@
      * Specific to the status
      */
 
-    .status-ok .summary { background: {{ .Site.Params.ok }}; }
-    .status-disrupted .summary, .change-header-color.status-disrupted .header { background: {{ .Site.Params.disrupted }}; }
-    .status-down .summary, .change-header-color.status-down .header { background: {{ .Site.Params.down }}; }
-    .status-notice .summary, .change-header-color.status-notice .header { background: {{ .Site.Params.notice }}; }
+{{- $ok := .Site.Params.ok -}}
+{{- $okR := (printf "0x%s" (substr $ok 1 2) | int) -}}
+{{- $okG := (printf "0x%s" (substr $ok 3 2) | int) -}}
+{{- $okB := (printf "0x%s" (substr $ok 5 2) | int) -}}
+
+{{- $disrupted := .Site.Params.disrupted -}}
+{{- $disruptedR := (printf "0x%s" (substr $disrupted 1 2) | int) -}}
+{{- $disruptedG := (printf "0x%s" (substr $disrupted 3 2) | int) -}}
+{{- $disruptedB := (printf "0x%s" (substr $disrupted 5 2) | int) -}}
+
+{{- $down := .Site.Params.down -}}
+{{- $downR := (printf "0x%s" (substr $down 1 2) | int) -}}
+{{- $downG := (printf "0x%s" (substr $down 3 2) | int) -}}
+{{- $downB := (printf "0x%s" (substr $down 5 2) | int) -}}
+
+{{- $notice := .Site.Params.notice -}}
+{{- $noticeR := (printf "0x%s" (substr $notice 1 2) | int) -}}
+{{- $noticeG := (printf "0x%s" (substr $notice 3 2) | int) -}}
+{{- $noticeB := (printf "0x%s" (substr $notice 5 2) | int) -}}
+
+
+.status-ok .summary {
+  background: {{ .Site.Params.ok }};
+  box-shadow: 0 0 20px rgba({{ $okR }}, {{ $okG }}, {{ $okB }}, 0.3);
+	border-radius: 4px;
+}
+
+.status-disrupted .summary,
+.change-header-color.status-disrupted .header {
+  background: rgba({{ $disruptedR }}, {{ $disruptedG }}, {{ $disruptedB }}, 1);
+
+  box-shadow: 0 0 20px rgba({{ $disruptedR }}, {{ $disruptedG }}, {{ $disruptedB }}, 0.3);
+}
+
+.status-down .summary,
+.change-header-color.status-down .header {
+  background: rgba({{ $downR }}, {{ $downG }}, {{ $downB }}, 1);
+}
+
+.status-notice .summary,
+.change-header-color.status-notice .header {
+  background: rgba({{ $noticeR }}, {{ $noticeG }}, {{ $noticeB }}, 1);
+}
+
 
     .announcement-box .padding {
       padding: 16px;
@@ -364,16 +404,16 @@
       /**
       * Dark theme
       */
-      
+
       @media (prefers-color-scheme: dark) {
         /* Basics */
         html, body { background:  #181a1b; color: #ccc9c1; }
         h1, h2, h3, h4, a, .bold { color: #fafafa; }
         hr { border-bottom-color: #3d3d3d; }
-        
+
         /* Sections */
         .footer { background: #1b1d1e; }
-        
+
         .components {
           border: 2px solid #ddd;
           border-bottom: 0;
@@ -407,7 +447,7 @@
         .error { color: #ff4242; }
         .warning {color: #ffde7f; }
         .ok { color: #7fff7f; }
- 
+
         .component[data-status="ok"] .component-status,
         .category__head[data-status="ok"] .category-status
         { color: #7fff7f; }

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -158,6 +158,7 @@
       padding: 4px 8px;
       margin-right: 4px;
       margin-bottom: 2px;
+	  border: none;
       background: #eee;
     }
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -46,8 +46,8 @@
       border-bottom: 1px dotted currentColor;
     }
 
-    a:hover { border-bottom-style: solid; }
-    a:active { position: relative; top: 2px; }
+    a:hover { opacity: 0.9; }
+    a:active { opacity: 0.8; }
 
     hr {
       border: 0;
@@ -222,7 +222,7 @@
     }
 
     .summary__date:hover {
-      color: #ccc;
+      opacity: 0.8;
     }
 
     .summary__date:hover:after {
@@ -251,18 +251,25 @@
     .tooltip:active .tooltip__text  {
       display: block;
       position: absolute;
+	  animation: fadeUp 0.1s cubic-bezier(0.39, 0.575, 0.565, 1);
       top: 0;
       left: 24px;
-      background: #181818;
+      background: #000;
       color: #fff;
       z-index: 50;
       padding: 8px;
-      border: 2px solid #242424;
+	  border-radius: 4px;
+	  box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
       font-size: 14px;
       color: #ccc;
       width: 320px;
       height: auto;
     }
+
+	@keyframes fadeUp {
+	  0% { opacity: 0; transform: translateY(5px); }
+	  100% { opacity: 1; transform: translateY(0); }
+	}
 
     @media (max-width: 640px) {
       .tooltip:hover .tooltip__text,
@@ -444,7 +451,7 @@
 
         /* Colors for dark mode */
 
-        .hinted, .faded { color: #c1bcb3; }
+        .hinted, .faded { opacity: 0.8; }
         .error { color: #ff4242; }
         .warning {color: #ffde7f; }
         .ok { color: #7fff7f; }

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -12,7 +12,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
-    <meta name="generator" content="cState v5.6.1 - https://github.com/cstate/cstate">
+    <meta name="generator" content="cState v6.0 - https://github.com/cstate/cstate">
     <meta name="theme-color" content="{{ .Site.Params.brand }}">
     <script>
     var themeBrandColor = '{{ .Site.Params.brand }}';

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -88,6 +88,18 @@
      * Classes
      */
 
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border-width: 0;
+	}
+
     a.no-underline { border-bottom: 0; }
 
     .headline { font-size: 20px; }
@@ -135,6 +147,11 @@
     .js .category--closed .components { display: none; }
     .js .category--closed .category__open-marker { display: none; }
 
+	.hide-without-js svg {
+		position: relative;
+		margin-bottom: -6px;
+	}
+
     /* Markers */
     .js .hidden-with-js { display: none; }
     .hide-without-js { display: none; }
@@ -158,11 +175,15 @@
       padding: 4px 8px;
       margin-right: 4px;
       margin-bottom: 2px;
+	  border-radius: 4px;
+	  transition: background 0.2s;
+	  cursor: pointer;
 	  border: none;
       background: #eee;
     }
 
     .tag:hover { background: #ddd; }
+	.tag:active { background: #ccc; }
 
     /**
      * Section blocks
@@ -308,7 +329,7 @@
      * Articles
      */
 
-    .issue { display: block; padding: 14px 24px; }
+    .issue { display: block; padding: 14px 24px; border-radius: 4px; }
     .issue:hover, .category__head:hover { background: #f5f5f5; }
     .issue:active, .category__head:active { background: #eee; }
 

--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,7 @@ license = "MIT"
 licenselink = "https://github.com/cstate/cstate/blob/master/LICENSE.md"
 description = "Über fast, backwards compatible (IE8+), tiny, and simple status page. Compatible with Netlify & GitHub Pages."
 homepage = "https://github.com/cstate/cstate"
-tags = ['hugo', 'netlify', 'status', 'statuspage', 'fast', 'light', 'ie8', 'ie9', 'ie10', 'ie11', 'github', 'github-pages', 'gh-pages', 'serverside', 'serverless', 'no-javascript', 'github-page', 'netlify-cms', 'gh-pages', 'responsive', 'minimal', 'google analytics', 'clean', 'minimalist', 'light', 'product', 'technical', 'widgets', 'products', 'mobile', 'onepage', 'singlepage', 'single page', 'spa']
+tags = ['hugo', 'netlify', 'status', 'statuspage', 'fast', 'light', 'ie9', 'ie10', 'ie11', 'github', 'github-pages', 'gh-pages', 'serverside', 'serverless', 'no-javascript', 'github-page', 'netlify-cms', 'gh-pages', 'responsive', 'minimal', 'google analytics', 'clean', 'minimalist', 'light', 'product', 'technical', 'widgets', 'products', 'mobile', 'onepage', 'singlepage', 'single page', 'spa']
 min_version = "0.80.0"
 
 [author]


### PR DESCRIPTION
# Version 6 Changelog and Migration Guide - Plus Unique New Add-Ons

**A bigger focus on command-line and future automation support, a refreshed but still familiar design, and more.**

This update has breaking changes to CSS, changes to the config file, and some fun, long awaited features.

## **A paid Pro version of cState with support is coming**

### Support development!

If you want to support me, [[go to my sponsors page](https://github.com/sponsors/mistermantas)](https://github.com/sponsors/mistermantas) or, better yet, hire me for your project (you can email me using my profile email).

The upcoming Pro version of cState is not set to replace the open source version of cState but simply to make setting up everything, including monitoring, much easier. 

## Changes available today

> ⚠ It is recommend to upgrade to Hugo version **0.140.0** (the minimum Hugo version is **0.110.0**).
> 
- **https://github.com/cstate/cstate-cli CLI tool - make new posts easier than ever before with a global `cstate` command.** Learn more on the repo page about `cstate dev` and many other commands
    - Read more here: https://github.com/cstate/cstate/issues/333
- **Free monitoring bot now available.** We’re introducing a bot to monitor for downtime and update cState programmatically. This is the current replacement for a POST API while maintaining the same unique structure of cState. https://github.com/cstate/monitorbot
- **Added a histogram, enabled by default for every component,** drawing stats from the data cState already has – to enable when upgrading, add a `.Site.Params.enableUptimeHistogram` option as true.
- **Updated base design CSS and introduced new detail details**, thus IE8 is no longer supported. New default font is DM Sans, replaceable with Custom HTML by creating a file under `/layouts/partials/custom/meta.html`.
- **Better component pages.** Extended description support is officially added (plus system pages now show the status) - #270
- Added /issues/ for viewing - and an option to hide a part of your incident history - #286
- Added Romanian language #335 from MarcUs7i
- T**he Netlify CMS `/admin` backend has been removed by default**, since it’s been discontinued and the Netlify CMS’s successor Decap CMS is included **at custom site level by default** in `exampleSite` if you still want to use it.
- **Fixes community raised issues, some of which are years old -**  #275, #330, #287, #320, #286,  #257, #270
- New translation strings updated with AI

## Coming later this year

- **Notifications and the Subscribe button** - all pages have an API and RSS option by default, with push notifications now available later this year with service workers or a monitor bot (cstate/monitorbot) for other services like Discord, Webhook URLs and more. These updates will be pushed to the repo and a future version of cState.


---

## Also available: cState HTML Embed

[![UI screenshots](https://github.com/user-attachments/assets/2deadd73-4ca0-4193-b777-876fae8ef6d2)](https://github.com/cstate/html-embed)


[Learn more](https://github.com/cstate/html-embed)


 
## `cstate-cli` is here to make managing your cState status page a breeze! 🚀

I'm excited to announce the first release of `cstate-cli`, a command-line tool designed to simplify creating and managing content for your **cState** status pages.

**What it does:**

*   ⚡️ **`cstate create`:**  Interactively create new incident or informational posts.
*   📝 **`cstate draft`:** Quickly draft posts from templates (Incident Post, Maintenance, Experiment, Postmortem).
*   💻 **`cstate dev`:**  Run a local Hugo development server with the cState theme.
*   🔨 **`cstate serve` & `cstate build`:** Handy aliases for Hugo's `serve` and `build` commands.

**Why you'll love it:**

*   **Saves time:** Automates tedious tasks.
*   **Reduces errors:** Ensures consistent formatting.
*   **Improves workflow:** Streamlines content creation.

**Get started:**

```bash
# Install globally
npm install -g cstate-cli

# Or use with npx
npx cstate-cli <command>
```

**Example:**

```bash
cstate draft
```

This will prompt you to choose a template and guide you through creating a new post.

**Check out the full documentation and usage instructions in the README.**

I hope you find `cstate-cli` helpful! Feedback and contributions are always welcome. ✨
 