### PR TITLE
fix broken link on RSS feeds

### DIFF
--- a/layouts/partials/index/summary.html
+++ b/layouts/partials/index/summary.html
@@ -30,7 +30,7 @@
 				</button>
 				<div class="subscribe-dropdown hidden" aria-label="{{ T "closeDropdown" }}">
 					<ul>
-						<a href="{{ .Site.BaseURL }}/index.xml" target="_blank" rel="noopener noreferrer">
+						<a href="{{ .Site.BaseURL }}index.xml" target="_blank" rel="noopener noreferrer">
 						<li>
 							<svg viewBox="0 0 512 512" class="subscribe-dropdown__icon">
 								<path d="M108.56 342.78a60.34 60.34 0 1 0 60.56 60.44 60.63 60.63 0 0 0-60.56-60.44Z">
@@ -407,7 +407,7 @@
 							modalTitle.textContent = '{{ T "rss" }}';
 							modalContent.innerHTML = `<p>{{ T "subscribeDescription" }}</p>`;
 							modalActions.innerHTML = `
-							<a href="{{ .Site.BaseURL }}/index.xml" target="_blank" rel="noopener noreferrer" class="padding-s">{{ T "open" }}</a>
+							<a href="{{ .Site.BaseURL }}index.xml" target="_blank" rel="noopener noreferrer" class="padding-s">{{ T "open" }}</a>
           `;
 							break;
 


### PR DESCRIPTION
On the top "subscribe" button, the link has two
double-dashes. Surprisingly, this doesn't work.

For example, hosting our site on grebedoc.dev led to this link becoming a 404, and I suspect that's the page on any hosting provider behind a "git-pages" implementation. We can also reproduce this on our legacy Apache web servers.

We already require the base URL to have a trailing slash elsewhere, so let's not add a double here.

Closes: #357

**Test plan**

I've ran this locally and will shortly push a fix to our sites.